### PR TITLE
Silence stderr during py_compile.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ class Venv(setuptools.Command):
 
 setuptools.setup(
     name='shiv',
-    version='0.0.11',
+    version='0.0.12',
     description="A command line utility for building fully self contained Python zipapps.",
     packages=setuptools.find_packages('src'),
     package_dir={'': 'src'},

--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -8,7 +8,7 @@ from py_compile import compile
 
 from .environment import Environment
 from .interpreter import execute_interpreter
-from .utils import current_zipfile
+from .utils import current_zipfile, silence_stderr
 
 
 def import_string(import_name):
@@ -69,9 +69,10 @@ def extract_site_packages(archive, target_path):
         if filename.startswith("site-packages"):
             archive.extract(filename, target_path_tmp)
 
-    # compile pyc
-    for py_file in target_path_tmp.glob('**/*.py'):
-        compile(py_file)
+    # compile pyc with stderr silenced
+    with silence_stderr():
+        for py_file in target_path_tmp.glob('**/*.py'):
+            compile(py_file)
 
     # atomic move
     shutil.move(target_path_tmp.as_posix(), target_path.as_posix())

--- a/src/shiv/bootstrap/utils.py
+++ b/src/shiv/bootstrap/utils.py
@@ -1,5 +1,17 @@
+import os
 import sys
 import zipfile
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def silence_stderr():
+    with open(os.devnull, 'w') as devnull:
+        stderr = sys.stderr
+        sys.stderr = devnull
+        yield
+        sys.stderr = stderr
 
 
 def current_zipfile():


### PR DESCRIPTION
Where formerly you might see:
```
❱❱❱ ./test.pyz
  File "/Users/lcarvalh/.shiv/test_8de01bf3-790b-4320-a020-ddba2ba08eba.tmp/site-packages/parsimonious/tests/benchmarks.py", line 91
    print 'Took %.3fs to parse %.1fKB: %.0fKB/s.' % (seconds_each,
                                                ^
SyntaxError: invalid syntax

Python 3.6.1 (default, Apr 19 2017, 15:02:08)
[GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> ^D
now exiting InteractiveConsole...
```

You will now see:
```
❱❱❱ ~/test.pyz
Python 3.6.1 (default, Apr 19 2017, 15:02:08)
[GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> ^D
now exiting InteractiveConsole...
```