### PR TITLE
Support creating pyz files for different platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ requirements = [
     'click==6.7',
     'pip>=9.0.1',
     'importlib_resources>=0.4',
+    'wheel',
 ]
 
 # The following template and classmethod are copied from

--- a/src/shiv/constants.py
+++ b/src/shiv/constants.py
@@ -1,5 +1,5 @@
 """This module contains various error messages."""
-from typing import Tuple, Dict
+from typing import Dict, Set, Tuple
 
 # errors:
 DISALLOWED_PIP_ARGS = "\nYou supplied a disallowed pip argument! '{arg}'\n\n{reason}\n"
@@ -8,14 +8,13 @@ NO_OUTFILE = "\nYou must provide an output file option! (--output-file/-o)\n"
 NO_ENTRY_POINT = "\nNo entry point '{entry_point}' found in the console_scripts!\n"
 PIP_INSTALL_ERROR = "\nPip install failed!\n"
 BINPRM_ERROR = "\nShebang is too long, it would exceed BINPRM_BUF_SIZE! Consider /usr/bin/env"
+PIP_DOWNLOAD_ERROR = "\nPip download failed!\n"
+PIP_WHEEL_ERROR = "\nPip wheel failed!\n"
 
 # pip
-PIP_INSTALL_ERROR = "\nPip install failed!\n"
 PIP_REQUIRE_VIRTUALENV = "PIP_REQUIRE_VIRTUALENV"
 BLACKLISTED_ARGS: Dict[Tuple[str, ...], str] = {
-    ("-t", "--target"): "Shiv already supplies a target internally, so overriding is not allowed.",
-    ("--editable", ): "Editable installs don't actually install via pip (they are just linked), so they are not allowed.",
-    ("-d", "--download"): "Shiv needs to actually perform an install, not merely a download.",
-    ("--user", "--root", "--prefix"): "Which conflicts with Shiv's internal use of '--target'.",
+    ("-d", "--dest"): "Shiv already supplies a destination internally, so overriding is not allowed.",
+    ("-w", "--wheel-dir"): "Shiv already supplies a wheel dir internally, so overriding is not allowed.",
 }
 DISTUTILS_CFG_NO_PREFIX = "[install]\nprefix="

--- a/src/shiv/pip.py
+++ b/src/shiv/pip.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 from typing import Generator, List
 
-from .constants import PIP_REQUIRE_VIRTUALENV, PIP_INSTALL_ERROR, DISTUTILS_CFG_NO_PREFIX
+from .constants import PIP_REQUIRE_VIRTUALENV, PIP_DOWNLOAD_ERROR, PIP_WHEEL_ERROR, DISTUTILS_CFG_NO_PREFIX
 
 
 @contextlib.contextmanager
@@ -42,25 +42,22 @@ def clean_pip_env() -> Generator[None, None, None]:
             pydistutils.unlink()
 
 
-def install(args: List[str]) -> None:
-    """`pip install` as a function.
+def download(args: List[str]) -> None:
+    """`pip download` as a function.
 
     Accepts a list of pip arguments.
 
     .. code-block:: py
 
-        >>> install(['numpy', '--target', 'site-packages'])
+        >>> download(['numpy', '--dest', 'site-packages'])
         Collecting numpy
         Downloading numpy-1.13.3-cp35-cp35m-manylinux1_x86_64.whl (16.9MB)
             100% || 16.9MB 53kB/s
-        Installing collected packages: numpy
-        Successfully installed numpy-1.13.3
-
     """
     with clean_pip_env():
 
         process = subprocess.Popen(
-            [sys.executable, "-m", "pip", "--disable-pip-version-check", "install"] + args,
+            [sys.executable, "-m", "pip", "--disable-pip-version-check", "download"] + args,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
@@ -70,4 +67,33 @@ def install(args: List[str]) -> None:
                 print(output.decode().rstrip())
 
         if process.wait() > 0:
-            sys.exit(PIP_INSTALL_ERROR)
+            sys.exit(PIP_DOWNLOAD_ERROR)
+
+
+def wheel(args: List[str]) -> None:
+    """`pip wheel` as a function.
+
+    Accepts a list of pip arguments.
+
+    .. code-block:: py
+
+        >>> wheel(['numpy', '--wheel-dir', 'site-packages'])
+        Collecting numpy
+        Downloading https://files.pythonhosted.org/packages/8e/75/7a8b7e3c073562563473f2a61bd53e75d0a1f5e2047e576ee61d44113c22/numpy-1.14.3-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl (4.7MB)
+        Saved ./site-packages/numpy-1.14.3-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+        Skipping numpy, due to already being wheel.
+    """
+    with clean_pip_env():
+
+        process = subprocess.Popen(
+            [sys.executable, "-m", "pip", "--disable-pip-version-check", "wheel"] + args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        for output in process.stdout:
+            if output:
+                print(output.decode().rstrip())
+
+        if process.wait() > 0:
+            sys.exit(PIP_WHEEL_ERROR)


### PR DESCRIPTION
I need to add tests and docs for this, but I just wanted to post this before the weekend since I've actually gotten it working.

The key changes are:

1.  Use `pip download` + `wheel install` instead of `pip install` for installing wheels. This way you can force installation into a directory even with incompatible wheels, and you can rely on `pip download` to get the correct wheels for a different platform.
2.  Stop enforcing that `--python` exists, since you might be creating a `.pyz` file for a different machine.
3.  Fix a bug in `map_shared_objects` where some internal `.so` files used by `numpy` would break the `module_name` splitting code.

If you want to try it out, just run:

```
shiv -p /path/to/python36/on/other/machine/python3 -o foo.pyz --python-version 36 --platform manylinux1_x86_64 --abi cp36m --implementation cp --only-binary=:all: Cython numpy
```

I didn't add any special args for cross-platform stuff, since we can rely on the pip download flags.