### PR TITLE
Write a temporary setup.cfg to override any system distutils configuration

### DIFF
--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -126,6 +126,7 @@ def main(
     interpreter = validate_interpreter(python)
 
     with TemporaryDirectory() as working_path:
+        cwd = Path.cwd()
         # distutils doesn't support using --target if there's a config file
         # specifying --prefix. Homebrew's Pythons include a distutils.cfg that
         # breaks `pip install --target` with any non-wheel packages. We can
@@ -143,6 +144,9 @@ def main(
             python or sys.executable,
             ["--target", site_packages.as_posix()] + list(pip_args),
         )
+
+        # return to the previous working directory
+        os.chdir(cwd)
 
         # if entry_point is a console script, get the callable
         if entry_point is None and console_script is not None:

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -1,4 +1,5 @@
 import importlib_resources  # type: ignore
+import os
 import shutil
 import sys
 import uuid
@@ -125,6 +126,15 @@ def main(
     interpreter = validate_interpreter(python)
 
     with TemporaryDirectory() as working_path:
+        # distutils doesn't support using --target if there's a config file
+        # specifying --prefix. Homebrew's Pythons include a distutils.cfg that
+        # breaks `pip install --target` with any non-wheel packages. We can
+        # work around that by creating a setup.cfg specifying an empty prefix
+        # in the directory we run `pip install` from.
+        with Path(working_path, "setup.cfg").open('w') as f:
+            f.write('[install]\nprefix=')
+        os.chdir(working_path)
+
         site_packages = Path(working_path, "site-packages")
         site_packages.mkdir(parents=True, exist_ok=True)
 

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -1,5 +1,4 @@
 import importlib_resources  # type: ignore
-import os
 import shutil
 import sys
 import uuid
@@ -126,16 +125,6 @@ def main(
     interpreter = validate_interpreter(python)
 
     with TemporaryDirectory() as working_path:
-        cwd = Path.cwd()
-        # distutils doesn't support using --target if there's a config file
-        # specifying --prefix. Homebrew's Pythons include a distutils.cfg that
-        # breaks `pip install --target` with any non-wheel packages. We can
-        # work around that by creating a setup.cfg specifying an empty prefix
-        # in the directory we run `pip install` from.
-        with Path(working_path, "setup.cfg").open('w') as f:
-            f.write('[install]\nprefix=')
-        os.chdir(working_path)
-
         site_packages = Path(working_path, "site-packages")
         site_packages.mkdir(parents=True, exist_ok=True)
 
@@ -144,9 +133,6 @@ def main(
             python or sys.executable,
             ["--target", site_packages.as_posix()] + list(pip_args),
         )
-
-        # return to the previous working directory
-        os.chdir(cwd)
 
         # if entry_point is a console script, get the callable
         if entry_point is None and console_script is not None:

--- a/src/shiv/constants.py
+++ b/src/shiv/constants.py
@@ -18,3 +18,4 @@ BLACKLISTED_ARGS: Dict[Tuple[str, ...], str] = {
     ("-d", "--download"): "Shiv needs to actually perform an install, not merely a download.",
     ("--user", "--root", "--prefix"): "Which conflicts with Shiv's internal use of '--target'.",
 }
+SETUP_CFG_NO_PREFIX = "[install]\nprefix="

--- a/src/shiv/pip.py
+++ b/src/shiv/pip.py
@@ -3,9 +3,11 @@ import os
 import subprocess
 import sys
 
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Generator, List
 
-from .constants import PIP_REQUIRE_VIRTUALENV, PIP_INSTALL_ERROR
+from .constants import PIP_REQUIRE_VIRTUALENV, PIP_INSTALL_ERROR, SETUP_CFG_NO_PREFIX
 
 
 @contextlib.contextmanager
@@ -16,13 +18,27 @@ def clean_pip_env() -> Generator[None, None, None]:
 
     """
     require_venv = os.environ.pop(PIP_REQUIRE_VIRTUALENV, None)
+    cwd = Path.cwd()
 
-    try:
-        yield
+    with TemporaryDirectory() as working_path:
+        # distutils doesn't support using --target if there's a config file
+        # specifying --prefix. Homebrew's Pythons include a distutils.cfg that
+        # breaks `pip install --target` with any non-wheel packages. We can
+        # work around that by creating a setup.cfg specifying an empty prefix
+        # in the directory we run `pip install` from.
+        with Path(working_path, "setup.cfg").open("w") as f:
+            f.write(SETUP_CFG_NO_PREFIX)
+        os.chdir(working_path)
 
-    finally:
-        if require_venv is not None:
-            os.environ[PIP_REQUIRE_VIRTUALENV] = require_venv
+        try:
+            yield
+
+        finally:
+            if require_venv is not None:
+                os.environ[PIP_REQUIRE_VIRTUALENV] = require_venv
+
+            # return to the previous working directory
+            os.chdir(cwd)
 
 
 def install(interpreter_path: str, args: List[str]) -> None:

--- a/test/test_pip.py
+++ b/test/test_pip.py
@@ -1,0 +1,26 @@
+import os
+
+from pathlib import Path
+
+from shiv.constants import PIP_REQUIRE_VIRTUALENV
+from shiv.constants import SETUP_CFG_NO_PREFIX
+from shiv.pip import clean_pip_env
+
+
+def test_clean_pip_env(monkeypatch):
+    before_env_var = 'foo'
+    monkeypatch.setenv(PIP_REQUIRE_VIRTUALENV, before_env_var)
+
+    before_cwd = Path.cwd()
+
+    with clean_pip_env():
+        assert PIP_REQUIRE_VIRTUALENV not in os.environ
+
+        cwd = Path.cwd()
+        assert cwd != before_cwd
+
+        with cwd.joinpath("setup.cfg").open() as f:
+            assert f.read() == SETUP_CFG_NO_PREFIX
+
+    assert os.environ.get(PIP_REQUIRE_VIRTUALENV) == before_env_var
+    assert Path.cwd() == before_cwd


### PR DESCRIPTION
Previously, shiv could not install packages that did not provide wheels using Homebrew's Pythons, because `--target` is incompatible with Homebrew's `distutils.cfg`. We can work around that by creating a `setup.cfg` in the same directory we run `pip install` containing:

```ini
[install]
prefix=
```

Fixes #16.