### PR TITLE
Add bumpversion config.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,11 @@ addopts = --ignore build/ --ignore dist/ test/
 mypy_path = src/
 strict_optional = yes
 disallow_untyped_defs = no
+
+[bumpversion]
+current_version = 0.0.17
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+[bumpversion:file:src/shiv/cli.py]


### PR DESCRIPTION
https://github.com/peritus/bumpversion

makes tagging/releasing versions easier