### PR TITLE
Write a temporary ~/.pydistutils.cfg to override any system distutils configuration

### DIFF
--- a/src/shiv/constants.py
+++ b/src/shiv/constants.py
@@ -18,3 +18,4 @@ BLACKLISTED_ARGS: Dict[Tuple[str, ...], str] = {
     ("-d", "--download"): "Shiv needs to actually perform an install, not merely a download.",
     ("--user", "--root", "--prefix"): "Which conflicts with Shiv's internal use of '--target'.",
 }
+DISTUTILS_CFG_NO_PREFIX = "[install]\nprefix="

--- a/src/shiv/pip.py
+++ b/src/shiv/pip.py
@@ -9,14 +9,6 @@ from typing import Generator, List
 from .constants import PIP_REQUIRE_VIRTUALENV, PIP_INSTALL_ERROR, DISTUTILS_CFG_NO_PREFIX
 
 
-def pydistutils_cfg() -> Path:
-    """distutils can be configured by ``pydistutils.cfg`` or ``.pydistutils.cfg`` in a user's home directory."""
-    try:
-        return next(Path.home().glob("*pydistutils.cfg"))
-    except StopIteration:
-        return Path.home() / ".pydistutils.cfg"
-
-
 @contextlib.contextmanager
 def clean_pip_env() -> Generator[None, None, None]:
     """A context manager for temporarily removing 'PIP_REQUIRE_VIRTUALENV' from the environment.
@@ -26,8 +18,11 @@ def clean_pip_env() -> Generator[None, None, None]:
     """
     require_venv = os.environ.pop(PIP_REQUIRE_VIRTUALENV, None)
 
-    pydistutils = pydistutils_cfg()
+    # based on
+    # https://github.com/python/cpython/blob/8cf4b34b3665b8bb39ea7111e6b5c3410899d3e4/Lib/distutils/dist.py#L333-L363
+    pydistutils = Path.home() / (".pydistutils.cfg" if os.name == "posix" else "pydistutils.cfg")
     pydistutils_already_existed = pydistutils.exists()
+
     if not pydistutils_already_existed:
         # distutils doesn't support using --target if there's a config file
         # specifying --prefix. Homebrew's Pythons include a distutils.cfg that

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,11 +1,23 @@
+import os
+
 from pathlib import Path
 
 import pytest
 
 
-@pytest.fixture
-def package_location():
-    return Path(__file__).absolute().parent / 'package'
+@pytest.fixture(params=[True, False], ids=['.', 'absolute-path'])
+def package_location(request):
+    package_location = Path(__file__).absolute().parent / 'package'
+
+    if request.param is True:
+        # test building from the current directory
+        cwd = os.getcwd()
+        os.chdir(package_location)
+        yield Path('.')
+        os.chdir(cwd)
+    else:
+        # test building an absolute path
+        yield package_location
 
 
 @pytest.fixture

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -45,11 +45,20 @@ class TestCLI:
         # assert we got the correct reason
         assert strip_header(result.output) == DISALLOWED_PIP_ARGS.format(arg=arg, reason=reason)
 
-    def test_hello_world(self, tmpdir, runner, package_location):
+    # /usr/local/bin/python3.6 is a test for https://github.com/linkedin/shiv/issues/16
+    @pytest.mark.parametrize('interpreter', [None, Path('/usr/local/bin/python3.6')])
+    def test_hello_world(self, tmpdir, runner, package_location, interpreter):
+        if interpreter is not None and not interpreter.exists():
+            pytest.skip(f'Interpreter "{interpreter}" does not exist')
+
         with tempfile.TemporaryDirectory(dir=tmpdir) as tmpdir:
             output_file = Path(tmpdir, 'test.pyz')
 
-            result = runner(['-e', 'hello:main', '-o', output_file.as_posix(), package_location.as_posix()])
+            args = ['-e', 'hello:main', '-o', output_file.as_posix(), package_location.as_posix()]
+            if interpreter is not None:
+                args = ['-p', interpreter.as_posix()] + args
+
+            result = runner(args)
 
             # check that the command successfully completed
             assert result.exit_code == 0

--- a/test/test_pip.py
+++ b/test/test_pip.py
@@ -1,0 +1,41 @@
+import os
+
+from pathlib import Path
+
+import pytest
+
+from shiv.constants import PIP_REQUIRE_VIRTUALENV, DISTUTILS_CFG_NO_PREFIX
+from shiv.pip import clean_pip_env
+
+
+@pytest.mark.parametrize("distutils_cfg_exists", [True, False])
+def test_clean_pip_env(monkeypatch, tmpdir, distutils_cfg_exists):
+    home = tmpdir.join("home").ensure(dir=True)
+    monkeypatch.setenv("HOME", home)
+
+    distutils_cfg = Path(home) / ".pydistutils.cfg"
+
+    if distutils_cfg_exists:
+        distutils_contents = "foobar"
+        distutils_cfg.write_text(distutils_contents)
+    else:
+        distutils_contents = None
+
+    before_env_var = "foo"
+    monkeypatch.setenv(PIP_REQUIRE_VIRTUALENV, before_env_var)
+
+    with clean_pip_env():
+        assert PIP_REQUIRE_VIRTUALENV not in os.environ
+
+        if not distutils_cfg_exists:
+            # ~/.pydistutils.cfg was created
+            assert distutils_cfg.read_text() == DISTUTILS_CFG_NO_PREFIX
+        else:
+            # ~/.pydistutils.cfg was not modified
+            assert distutils_cfg.read_text() == distutils_contents
+
+    assert os.environ.get(PIP_REQUIRE_VIRTUALENV) == before_env_var
+
+    # If a temporary ~/.pydistutils.cfg was created, it was deleted. If
+    # ~/.pydistutils.cfg already existed, it still exists.
+    assert distutils_cfg.exists() == distutils_cfg_exists

--- a/test/test_pip.py
+++ b/test/test_pip.py
@@ -8,13 +8,20 @@ from shiv.constants import PIP_REQUIRE_VIRTUALENV, DISTUTILS_CFG_NO_PREFIX
 from shiv.pip import clean_pip_env
 
 
-@pytest.mark.parametrize("pydistutils_exists", ["pydistutils.cfg", ".pydistutils.cfg", None])
-def test_clean_pip_env(monkeypatch, tmpdir, pydistutils_exists):
+@pytest.mark.parametrize("pydistutils_path, os_name", [
+    ("pydistutils.cfg", "nt"),
+    (".pydistutils.cfg", "posix"),
+    (None, os.name),
+])
+def test_clean_pip_env(monkeypatch, tmpdir, pydistutils_path, os_name):
     home = tmpdir.join("home").ensure(dir=True)
     monkeypatch.setenv("HOME", home)
 
-    if pydistutils_exists:
-        pydistutils = Path.home() / pydistutils_exists
+    # patch os.name so distutils will use `pydistutils_path` for its config
+    monkeypatch.setattr(os, 'name', os.name)
+
+    if pydistutils_path:
+        pydistutils = Path.home() / pydistutils_path
         pydistutils_contents = "foobar"
         pydistutils.write_text(pydistutils_contents)
     else:
@@ -27,7 +34,7 @@ def test_clean_pip_env(monkeypatch, tmpdir, pydistutils_exists):
     with clean_pip_env():
         assert PIP_REQUIRE_VIRTUALENV not in os.environ
 
-        if not pydistutils_exists:
+        if not pydistutils_path:
             # ~/.pydistutils.cfg was created
             assert pydistutils.read_text() == DISTUTILS_CFG_NO_PREFIX
         else:
@@ -38,4 +45,4 @@ def test_clean_pip_env(monkeypatch, tmpdir, pydistutils_exists):
 
     # If a temporary ~/.pydistutils.cfg was created, it was deleted. If
     # ~/.pydistutils.cfg already existed, it still exists.
-    assert pydistutils.exists() == bool(pydistutils_exists)
+    assert pydistutils.exists() == bool(pydistutils_path)


### PR DESCRIPTION
Previously, shiv could not install packages that did not provide wheels using Homebrew's Pythons, because `--target` is incompatible with Homebrew's `distutils.cfg`. We can work around that by creating a temporary `~/.pydistutils.cfg` containing:

```ini
[install]
prefix=
```

Fixes #16. This time with tests for #16 and #22!

Inspired by https://github.com/Azure/azure-cli/pull/4466.