### PR TITLE
Fix coverage paths in coveralls and enable branch coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,16 @@ exclude = docs test/package/setup.py
 [tool:pytest]
 addopts = --ignore build/ --ignore dist/ test/
 
+[coverage:run]
+source = shiv
+branch = True
+
+[coverage:paths]
+source =
+    src/shiv
+    .tox/*/lib/python*/site-packages/shiv
+    .tox/pypy*/site-packages/shiv
+
 [mypy]
 mypy_path = src/
 strict_optional = yes

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py36
 [testenv]
 passenv = TRAVIS TRAVIS_*
 commands=
-  py.test --cov=shiv
+  py.test --cov --cov-config=setup.cfg
   mypy src/
   flake8 src/ test/
 deps=


### PR DESCRIPTION
This _should_ fix the paths in coveralls so that it can actually show the lines of code covered/uncovered.