### PR TITLE
Loosen restrictions on shebang.

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -36,9 +36,11 @@ injecting said dependencies at runtime. We have to credit the great work by @wic
 The primary differences between PEX and shiv are:
 
 * ``shiv`` completey avoids the use of ``pkg_resources``. If it is included by a transitive
-  dependency, the performance implications are mitigated by limiting the length of ``sys.path`` and
-  always including the `-s <https://docs.python.org/3/using/cmdline.html#cmdoption-s>`_ and
-  `-E <https://docs.python.org/3/using/cmdline.html#cmdoption-e>`_ Python interpreter flags.
+  dependency, the performance implications are mitigated by limiting the length of ``sys.path``.
+  Internally, at LinkedIn, we always include the
+  `-s <https://docs.python.org/3/using/cmdline.html#cmdoption-s>`_ and
+  `-E <https://docs.python.org/3/using/cmdline.html#cmdoption-e>`_ Python interpreter flags by
+  specifying ``--python "/path/to/python -sE"``, which ensures a clean environment.
 * Instead of shipping our binary with downloaded wheels inside, we package an entire site-packages
   directory, as installed by ``pip``. We then bootstrap that directory post-extraction via the
   stdlib's ``site.addsitedir`` function. That way, everything works out of the box: namespace

--- a/src/shiv/constants.py
+++ b/src/shiv/constants.py
@@ -5,9 +5,9 @@ from typing import Tuple, Dict
 DISALLOWED_PIP_ARGS = "\nYou supplied a disallowed pip argument! '{arg}'\n\n{reason}\n"
 NO_PIP_ARGS = "\nYou must supply PIP ARGS!\n"
 NO_OUTFILE = "\nYou must provide an output file option! (--output-file/-o)\n"
-INVALID_PYTHON = "\nInvalid python interpreter! {path} does not exist!\n"
 NO_ENTRY_POINT = "\nNo entry point '{entry_point}' found in the console_scripts!\n"
 PIP_INSTALL_ERROR = "\nPip install failed!\n"
+BINPRM_ERROR = "\nShebang is too long, it would exceed BINPRM_BUF_SIZE! Consider /usr/bin/env"
 
 # pip
 PIP_INSTALL_ERROR = "\nPip install failed!\n"

--- a/src/shiv/pip.py
+++ b/src/shiv/pip.py
@@ -42,14 +42,14 @@ def clean_pip_env() -> Generator[None, None, None]:
             pydistutils.unlink()
 
 
-def install(interpreter_path: str, args: List[str]) -> None:
+def install(args: List[str]) -> None:
     """`pip install` as a function.
 
     Accepts a list of pip arguments.
 
     .. code-block:: py
 
-        >>> install('/usr/local/bin/python3', ['numpy', '--target', 'site-packages'])
+        >>> install(['numpy', '--target', 'site-packages'])
         Collecting numpy
         Downloading numpy-1.13.3-cp35-cp35m-manylinux1_x86_64.whl (16.9MB)
             100% || 16.9MB 53kB/s
@@ -60,7 +60,7 @@ def install(interpreter_path: str, args: List[str]) -> None:
     with clean_pip_env():
 
         process = subprocess.Popen(
-            [interpreter_path, "-m", "pip", "--disable-pip-version-check", "install"] + args,
+            [sys.executable, "-m", "pip", "--disable-pip-version-check", "install"] + args,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -8,6 +8,8 @@ from code import interact
 from uuid import uuid4
 from zipfile import ZipFile
 
+import pytest
+
 from unittest import mock
 
 from shiv.bootstrap import import_string, current_zipfile, cache_path
@@ -32,6 +34,14 @@ class TestBootstrap:
         func = import_string('os.path:join')
         from os.path import join
         assert func == join
+
+        # test something already imported
+        import shiv
+        assert import_string('shiv') == shiv == sys.modules['shiv']
+
+        # test bogus imports raise properly
+        with pytest.raises(ImportError):
+            import_string('this is bogus!')
 
     def test_is_zipfile(self, zip_location):
         assert not current_zipfile()

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -8,36 +8,54 @@ from zipapp import ZipAppError
 
 import pytest
 
-from shiv.cli import validate_interpreter
 from shiv.builder import write_file_prefix, create_archive
 
 
 UGOX = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
 
 
-class TestBuilder:
-    def test_file_prefix(self):
-        with tempfile.TemporaryFile() as fd:
-            python = validate_interpreter(Path(sys.executable))
-            write_file_prefix(fd, python)
-            fd.seek(0)
-            written = fd.read()
+def tmp_write_prefix(interpreter):
+    with tempfile.TemporaryFile() as fd:
+        write_file_prefix(fd, interpreter)
+        fd.seek(0)
+        written = fd.read()
 
-        assert written == b'#!' + python.as_posix().encode(sys.getdefaultencoding()) + b' -sE\n'
+    return written
+
+
+class TestBuilder:
+    @pytest.mark.parametrize(
+        'interpreter,expected', [
+            ('/usr/bin/python', b'#!/usr/bin/python\n'),
+            ('/usr/bin/env python', b'#!/usr/bin/env python\n'),
+            ('/some/other/path/python -sE', b'#!/some/other/path/python -sE\n'),
+        ]
+    )
+    def test_file_prefix(self, interpreter, expected):
+        assert tmp_write_prefix(interpreter) == expected
+
+    def test_binprm_error(self):
+        with pytest.raises(SystemExit):
+            tmp_write_prefix(f"/{'c' * 200}/python")
 
     def test_create_archive(self, sp):
         with tempfile.TemporaryDirectory() as tmpdir:
             target = Path(tmpdir, 'test.zip')
-            create_archive(sp, target, validate_interpreter(None), 'code:interact')
+
+            # create an archive
+            create_archive(sp, target, sys.executable, 'code:interact')
+
+            # create one again (to ensure we overwrite)
+            create_archive(sp, target, sys.executable, 'code:interact')
 
             assert zipfile.is_zipfile(str(target))
 
             with pytest.raises(ZipAppError):
-                create_archive(sp, target, validate_interpreter(None), 'alsjdbas,,,')
+                create_archive(sp, target, sys.executable, 'alsjdbas,,,')
 
     def test_archive_permissions(self, sp):
         with tempfile.TemporaryDirectory() as tmpdir:
             target = Path(tmpdir, 'test.zip')
-            create_archive(sp, target, validate_interpreter(None), 'code:interact')
+            create_archive(sp, target, sys.executable, 'code:interact')
 
             assert target.stat().st_mode & UGOX == UGOX

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,5 +1,4 @@
 import subprocess
-import sys
 import tempfile
 
 from pathlib import Path
@@ -8,7 +7,7 @@ import pytest
 
 from click.testing import CliRunner
 
-from shiv.cli import main, validate_interpreter
+from shiv.cli import main
 from shiv.constants import DISALLOWED_PIP_ARGS, NO_PIP_ARGS, NO_OUTFILE, BLACKLISTED_ARGS
 
 
@@ -69,13 +68,3 @@ class TestCLI:
             # now run the produced zipapp
             with subprocess.Popen([output_file], stdout=subprocess.PIPE) as proc:
                 assert proc.stdout.read().decode() == 'hello world\n'
-
-    def test_interpreter(self):
-        assert validate_interpreter(None) == validate_interpreter() == Path(sys.executable)
-
-        with pytest.raises(SystemExit):
-            validate_interpreter(Path('/usr/local/bogus_python'))
-
-    @pytest.mark.skipif(len(sys.executable) > 128, reason='only run this test is the shebang is not too long')
-    def test_real_interpreter(self):
-        assert validate_interpreter(Path(sys.executable)) == Path(sys.executable)


### PR DESCRIPTION
This commit loosens shiv's requirements when constructing a shebang
line: rather than enforcing that the target interpreter must exist, we
simply accept what the user provides.

We no longer append `-sE` to the shebang as these arguments can be
provided to the value given to the `--python` argument.

Shiv will now exit(1) if the resulting shebang would exceed the BIN_PRM
restrictions present on most unix-y OSes.

Fixes #17 

---

After merging I'll cut a new release (0.0.26)