### PR TITLE
enable testing on windows python3.6 and 3.7 with Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python36-x64"
+      TOXENV: "py36"
+
+    - PYTHON: "C:\\Python37-x64"
+      TOXENV: "py37"
+
+skip_branch_with_pr: true
+
+install:
+  # prepend the current Python to the PATH
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # check that we have the expected version and architecture for Python
+  - python --version
+  - python -c "import struct; print(struct.calcsize('P') * 8)"
+
+  # upgrade pip to avoid out-of-date warnings
+  - python -m pip install --disable-pip-version-check --upgrade pip
+
+  # install tox to run test suite in a virtual environment
+  - pip install tox
+
+build: false
+
+test_script:
+  - tox -e py
+
+on_success:
+  # upload test coverage to Coveralls
+  - pip install coveralls
+  - coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,9 @@ build: false
 test_script:
   - tox -e py
 
-on_success:
-  # upload test coverage to Coveralls
-  - pip install coveralls
-  - coveralls
+# TODO enable coveralls for Appveyor by setting secure COVERALLS_REPO_TOKEN
+# https://github.com/coveralls-net/coveralls.net/wiki/CI-Integrations#appveyor
+# on_success:
+#   # upload test coverage to Coveralls
+#   - pip install coveralls
+#   - coveralls

--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -80,7 +80,7 @@ def extract_site_packages(archive, target_path):
     compileall.compile_dir(target_path_tmp, quiet=2, workers=0)
 
     # atomic move
-    shutil.move(target_path_tmp.as_posix(), target_path.as_posix())
+    shutil.move(str(target_path_tmp), str(target_path))
 
 
 def bootstrap():

--- a/src/shiv/builder.py
+++ b/src/shiv/builder.py
@@ -94,4 +94,5 @@ def create_archive(
             z.writestr("__main__.py", main_py.encode("utf-8"))
 
     # make executable
+    # NOTE on windows this is no-op
     target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)

--- a/src/shiv/builder.py
+++ b/src/shiv/builder.py
@@ -88,7 +88,7 @@ def create_archive(
                     continue
 
                 arcname = child.relative_to(source)
-                z.write(child.as_posix(), arcname.as_posix())
+                z.write(str(child), str(arcname))
 
             # write main
             z.writestr("__main__.py", main_py.encode("utf-8"))

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -111,7 +111,7 @@ def main(
 
         # install deps into staged site-packages
         pip.install(
-            ["--target", site_packages.as_posix()] + list(pip_args),
+            ["--target", str(site_packages)] + list(pip_args),
         )
 
         # if entry_point is a console script, get the callable

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -44,7 +44,8 @@ class TestBootstrap:
             import_string('this is bogus!')
 
     def test_is_zipfile(self, zip_location):
-        assert not current_zipfile()
+        with mock.patch.object(sys, 'argv', [__file__]):
+            assert not current_zipfile()
 
         with mock.patch.object(sys, 'argv', [zip_location]):
             assert isinstance(current_zipfile(), ZipFile)

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -44,11 +44,15 @@ class TestBootstrap:
             import_string('this is bogus!')
 
     def test_is_zipfile(self, zip_location):
-        with mock.patch.object(sys, 'argv', [__file__]):
-            assert not current_zipfile()
-
         with mock.patch.object(sys, 'argv', [zip_location]):
             assert isinstance(current_zipfile(), ZipFile)
+
+    # When the tests are run via tox, sys.argv[0] is the full path to 'pytest.EXE',
+    # i.e. a native launcher created by pip to from console_scripts entry points.
+    # These are indeed a form of zip files, thus the following assertion could fail.
+    @pytest.mark.skipif(os.name == 'nt', reason="this may give false positive on win")
+    def test_argv0_is_not_zipfile(self):
+        assert not current_zipfile()
 
     def test_cache_path(self):
         mock_zip = mock.MagicMock(spec=ZipFile)

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -1,5 +1,6 @@
 import tempfile
 import stat
+import os
 import sys
 import zipfile
 
@@ -53,6 +54,8 @@ class TestBuilder:
             with pytest.raises(ZipAppError):
                 create_archive(sp, target, sys.executable, 'alsjdbas,,,')
 
+    @pytest.mark.skipif(os.name == 'nt',
+                        reason='windows has no concept of execute permissions')
     def test_archive_permissions(self, sp):
         with tempfile.TemporaryDirectory() as tmpdir:
             target = Path(tmpdir, 'test.zip')

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import tempfile
 
@@ -66,5 +67,5 @@ class TestCLI:
             assert output_file.exists()
 
             # now run the produced zipapp
-            with subprocess.Popen([str(output_file)], stdout=subprocess.PIPE) as proc:
-                assert proc.stdout.read().decode() == 'hello world\n'
+            with subprocess.Popen([str(output_file)], stdout=subprocess.PIPE, shell=True) as proc:
+                assert proc.stdout.read().decode() == "hello world" + os.linesep

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -54,9 +54,9 @@ class TestCLI:
         with tempfile.TemporaryDirectory(dir=tmpdir) as tmpdir:
             output_file = Path(tmpdir, 'test.pyz')
 
-            args = ['-e', 'hello:main', '-o', output_file.as_posix(), package_location.as_posix()]
+            args = ['-e', 'hello:main', '-o', str(output_file), str(package_location)]
             if interpreter is not None:
-                args = ['-p', interpreter.as_posix()] + args
+                args = ['-p', str(interpreter)] + args
 
             result = runner(args)
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -66,5 +66,5 @@ class TestCLI:
             assert output_file.exists()
 
             # now run the produced zipapp
-            with subprocess.Popen([output_file], stdout=subprocess.PIPE) as proc:
+            with subprocess.Popen([str(output_file)], stdout=subprocess.PIPE) as proc:
                 assert proc.stdout.read().decode() == 'hello world\n'

--- a/test/test_pip.py
+++ b/test/test_pip.py
@@ -25,7 +25,9 @@ def test_clean_pip_env(monkeypatch, tmpdir, pydistutils_path, os_name):
         pydistutils_contents = "foobar"
         pydistutils.write_text(pydistutils_contents)
     else:
-        pydistutils = Path.home() / ".pydistutils.cfg"
+        pydistutils = Path.home() / (
+            ".pydistutils.cfg" if os.name == "posix" else "pydistutils.cfg"
+        )
         pydistutils_contents = None
 
     before_env_var = "foo"


### PR DESCRIPTION
Here's a minimalist appveyor.yml file, running tox on python3.6 and python3.7 (64-bit only, I can add 32 if we want, though it's 2018).
 
Here's are the test failures I see with my own appveyor account linked to my anthrotype/shiv fork:
https://ci.appveyor.com/project/anthrotype/shiv/build/1.0.4

To make this work in the upstream repo, @sixninetynine should first merge this to master then grant Appveyor access to this public repo.

Since this is under the `linkedin` github organanization, the way Appveyor works for such repositories is slightly more complicated than Travis CI. 
Read more here:
https://www.appveyor.com/docs/team-setup/#setting-up-appveyor-account-for-github-organization