### PR TITLE
[WIP] Added more informative output - Addresses #42

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ target/
 .python-version
 .pytest_cache/
 venv/
+.venv
+.vscode
 activate
 
 # mypy

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ requirements = [
     'click==6.7',
     'pip>=9.0.1',
     'importlib_resources>=0.4',
+    'crayons>=0.1.2',
+    'blindspin>=2.0.1'
 ]
 
 # The following template and classmethod are copied from

--- a/src/shiv/pip.py
+++ b/src/shiv/pip.py
@@ -3,6 +3,9 @@ import os
 import subprocess
 import sys
 
+import click
+import crayons
+
 from pathlib import Path
 from typing import Generator, List
 
@@ -67,7 +70,7 @@ def install(args: List[str]) -> None:
 
         for output in process.stdout:
             if output:
-                print(output.decode().rstrip())
+                click.echo(crayons.blue(output.decode().rstrip()))
 
         if process.wait() > 0:
-            sys.exit(PIP_INSTALL_ERROR)
+            sys.exit(crayons.red(PIP_INSTALL_ERROR))


### PR DESCRIPTION
This my first attempt and may well err on the side of being too verbose. Appreciate any feedback on how to make it better.

- Show the args shiv will be using
- Notify the user which output file was written and if an automatic entry point has been applied
- color the ouput from pip in blue to distinguish it from whats coming from shiv. Matches Pipenv for user familiarity
- Color error messages in red

Here's some example output from a very simple 

```
Shiv! 🔪
with args :
	output file : 'test.pyz',
	entry point : 'test',
	python : '/Library/Frameworks/Python.framework/Versions/3.7/bin/python',
	compressed : True
	pip args 'arrow'
Pip installing dependencies to /var/folders/x_/h517ndbj2qx9m6ydt_vtsrv00000gn/T/tmphk62vpm_/site-packages...
Collecting arrow
Collecting python-dateutil (from arrow)
  Using cached https://files.pythonhosted.org/packages/cf/f5/af2b09c957ace60dcfac112b669c45c8c97e32f94aa8b56da4c6d1682825/python_dateutil-2.7.3-py2.py3-none-any.whl
Collecting six>=1.5 (from python-dateutil->arrow)
  Using cached https://files.pythonhosted.org/packages/67/4b/141a581104b1f6397bfa78ac9d43d8ad29a7ca43ea90a2d863fe3056e86a/six-1.11.0-py2.py3-none-any.whl
Installing collected packages: six, python-dateutil, arrow
Successfully installed arrow-0.12.1 python-dateutil-2.7.3 six-1.11.0
Injecting bootstrap code
Creating zip archive
Done, wrote output file to 'test.pyz', entry point is 'test'
```