### PR TITLE
shiv site_packages take precedence on sys.path

### DIFF
--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -1,4 +1,5 @@
 import compileall
+import site
 import sys
 import shutil
 import zipfile
@@ -98,8 +99,12 @@ def bootstrap():
     if not site_packages.exists() or env.force_extract:
         extract_site_packages(archive, site_packages.parent)
 
-    # shiv site_packages take precedence over anything else (eg: dist-packages)
+    # prepend shiv site-packages so it takes precedence over anything else (eg: dist-packages)
     sys.path.insert(1, str(site_packages))
+
+    # but also append site-packages using the stdlib blessed way of extending path
+    # so as to handle .pth files correctly
+    site.addsitedir(site_packages)
 
     # do entry point import and call
     if env.entry_point is not None and env.interpreter is None:

--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -1,5 +1,4 @@
 import compileall
-import site
 import sys
 import shutil
 import zipfile
@@ -99,8 +98,8 @@ def bootstrap():
     if not site_packages.exists() or env.force_extract:
         extract_site_packages(archive, site_packages.parent)
 
-    # stdlib blessed way of extending path
-    site.addsitedir(site_packages)
+    # shiv site_packages take precedence over anything else (eg: dist-packages)
+    sys.path.insert(1, str(site_packages))
 
     # do entry point import and call
     if env.entry_point is not None and env.interpreter is None:

--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -99,12 +99,13 @@ def bootstrap():
     if not site_packages.exists() or env.force_extract:
         extract_site_packages(archive, site_packages.parent)
 
-    # prepend shiv site-packages so it takes precedence over anything else (eg: dist-packages)
-    sys.path.insert(1, str(site_packages))
-
-    # but also append site-packages using the stdlib blessed way of extending path
+    # append site-packages using the stdlib blessed way of extending path
     # so as to handle .pth files correctly
     site.addsitedir(site_packages)
+
+    # pop the resolved path just added to the tail, and insert it after the head,
+    # so it takes precedence over anything else (eg: dist-packages)
+    sys.path.insert(1, sys.path.pop())
 
     # do entry point import and call
     if env.entry_point is not None and env.interpreter is None:

--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -99,13 +99,18 @@ def bootstrap():
     if not site_packages.exists() or env.force_extract:
         extract_site_packages(archive, site_packages.parent)
 
+    preserved = sys.path[1:]
+
+    # truncate the sys.path so our package will be at the start,
+    # and take precedence over anything else (eg: dist-packages)
+    sys.path = sys.path[0:1]
+
     # append site-packages using the stdlib blessed way of extending path
     # so as to handle .pth files correctly
     site.addsitedir(site_packages)
 
-    # pop the resolved path just added to the tail, and insert it after the head,
-    # so it takes precedence over anything else (eg: dist-packages)
-    sys.path.insert(1, sys.path.pop())
+    # restore the previous sys.path entries after our package
+    sys.path.extend(preserved)
 
     # do entry point import and call
     if env.entry_point is not None and env.interpreter is None:


### PR DESCRIPTION
I ran into an edge case (`ModuleNotFoundError`) where I had an older version of a dependency installed into dist-packages, that was being used instead of the shiv packaged version, because the shiv site-packages was at the end of `sys.path`:
```
>>> import sys; sys.path
['./ebbp', '/usr/lib/python36.zip', '/usr/lib/python3.6', '/usr/lib/python3.6/lib-dynload', '/home/tekumara/.local/lib/python3.6/site-packages', '/usr/local/lib/python3.6/dist-packages', '/usr/lib/python3/dist-packages', '/home/tekumara/.shiv/ebbp_921c47de-78d9-4ce4-a4cd-28426ed667e2/site-packages']
```

This change makes shiv zipapps more reliable, by placing shiv site-packages at the start of `sys.path`, rather than the end, eg:

```
>>> import sys; sys.path
['./ebbp', '/home/tekumara/.shiv/ebbp_921c47de-78d9-4ce4-a4cd-28426ed667e2/site-packages', '/usr/lib/python36.zip', '/usr/lib/python3.6', '/usr/lib/python3.6/lib-dynload', '/home/tekumara/.local/lib/python3.6/site-packages', '/usr/local/lib/python3.6/dist-packages', '/usr/lib/python3/dist-packages']
```
