### PR TITLE
Add a flag for controlling pyc compilation at bootstrap time.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,6 @@ commit = True
 tag = True
 
 [flake8]
-ignore = C901
 max-line-length = 160
 max-complexity = 12
 exclude = docs test/package/setup.py

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,19 @@ import venv
 from pathlib import Path
 from setuptools.command import easy_install
 
-requirements = [
+install_requires = [
     'click==6.7',
-    'pip>=9.0.1',
-    'importlib_resources>=0.4',
+    'pip>=9.0.3',
 ]
+
+extras_require = {
+    ":python_version<'3.7'": ["importlib_resources>=0.4"]
+}
+
+if int(setuptools.__version__.split('.')[0]) < 18:
+    extras_require = {}
+    if sys.version_info < (3, 7):
+        install_requires.append('importlib_resources>=0.4')
 
 # The following template and classmethod are copied from
 # fast entry points, Copyright (c) 2016, Aaron Christianson
@@ -110,7 +118,8 @@ setuptools.setup(
     url="https://github.com/linkedin/shiv",
     packages=setuptools.find_packages('src'),
     package_dir={'': 'src'},
-    install_requires=requirements,
+    install_requires=install_requires,
+    extras_require=extras_require,
     entry_points={
         'console_scripts': [
             'shiv = shiv.cli:main',
@@ -124,5 +133,6 @@ setuptools.setup(
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/src/shiv/bootstrap/environment.py
+++ b/src/shiv/bootstrap/environment.py
@@ -2,11 +2,16 @@
 This module contains the ``Environment`` object, which combines settings decided at build time with
 overrides defined at runtime (via environment variables).
 """
-import copy
 import json
 import os
 
 from pathlib import Path
+
+
+def str_bool(v):
+    if not isinstance(v, bool):
+        return str(v).lower() in ("yes", "true", "t", "1")
+    return v
 
 
 class Environment:
@@ -15,34 +20,37 @@ class Environment:
     MODULE = "SHIV_MODULE"
     ROOT = "SHIV_ROOT"
     FORCE_EXTRACT = "SHIV_FORCE_EXTRACT"
+    COMPILE_PYC = "SHIV_COMPILE_PYC"
+    COMPILE_WORKERS = "SHIV_COMPILE_WORKERS"
 
     def __init__(
         self,
         build_id=None,
         entry_point=None,
         always_write_cache=False,
+        compile_pyc=True,
     ):
         self.build_id = build_id
         self.always_write_cache = always_write_cache
 
         # properties
         self._entry_point = entry_point
+        self._compile_pyc = compile_pyc
 
     @classmethod
     def from_json(cls, json_data):
         return Environment(**json.loads(json_data))
 
     def to_json(self):
-        d = copy.copy(self.__dict__)
-        del d["_entry_point"]
-        d["entry_point"] = self.entry_point
-        return json.dumps(d)
+        return json.dumps(
+            # we strip the leading underscores to retain properties (such as _entry_point)
+            {key.lstrip("_"): value for key, value in self.__dict__.items()}
+        )
 
     @property
     def entry_point(self):
         return os.environ.get(
-            self.ENTRY_POINT,
-            os.environ.get(self.MODULE, self._entry_point),
+            self.ENTRY_POINT, os.environ.get(self.MODULE, self._entry_point)
         )
 
     @property
@@ -56,4 +64,15 @@ class Environment:
 
     @property
     def force_extract(self):
-        return bool(os.environ.get(self.FORCE_EXTRACT, self.always_write_cache))
+        return str_bool(os.environ.get(self.FORCE_EXTRACT, self.always_write_cache))
+
+    @property
+    def compile_pyc(self):
+        return str_bool(os.environ.get(self.COMPILE_PYC, self._compile_pyc))
+
+    @property
+    def compile_workers(self):
+        try:
+            return int(os.environ.get(self.COMPILE_WORKERS, 0))
+        except ValueError:
+            return 0

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -89,6 +89,18 @@ class TestEnvironment:
         with env_var('SHIV_FORCE_EXTRACT', '1'):
             assert env.force_extract is True
 
+        assert env.compile_pyc is True
+        with env_var("SHIV_COMPILE_PYC", "False"):
+            assert env.compile_pyc is False
+
+        assert env.compile_workers == 0
+        with env_var("SHIV_COMPILE_WORKERS", "1"):
+            assert env.compile_workers == 1
+
+        # ensure that non-digits are ignored
+        with env_var("SHIV_COMPILE_WORKERS", "one bazillion"):
+            assert env.compile_workers == 0
+
     def test_serialize(self):
         env = Environment()
         env_as_json = env.to_json()

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -25,12 +25,14 @@ def tmp_write_prefix(interpreter):
 
 
 class TestBuilder:
+
     @pytest.mark.parametrize(
-        'interpreter,expected', [
-            ('/usr/bin/python', b'#!/usr/bin/python\n'),
-            ('/usr/bin/env python', b'#!/usr/bin/env python\n'),
-            ('/some/other/path/python -sE', b'#!/some/other/path/python -sE\n'),
-        ]
+        "interpreter,expected",
+        [
+            ("/usr/bin/python", b"#!/usr/bin/python\n"),
+            ("/usr/bin/env python", b"#!/usr/bin/env python\n"),
+            ("/some/other/path/python -sE", b"#!/some/other/path/python -sE\n"),
+        ],
     )
     def test_file_prefix(self, interpreter, expected):
         assert tmp_write_prefix(interpreter) == expected
@@ -41,24 +43,25 @@ class TestBuilder:
 
     def test_create_archive(self, sp):
         with tempfile.TemporaryDirectory() as tmpdir:
-            target = Path(tmpdir, 'test.zip')
+            target = Path(tmpdir, "test.zip")
 
             # create an archive
-            create_archive(sp, target, sys.executable, 'code:interact')
+            create_archive(sp, target, sys.executable, "code:interact")
 
             # create one again (to ensure we overwrite)
-            create_archive(sp, target, sys.executable, 'code:interact')
+            create_archive(sp, target, sys.executable, "code:interact")
 
             assert zipfile.is_zipfile(str(target))
 
             with pytest.raises(ZipAppError):
-                create_archive(sp, target, sys.executable, 'alsjdbas,,,')
+                create_archive(sp, target, sys.executable, "alsjdbas,,,")
 
-    @pytest.mark.skipif(os.name == 'nt',
-                        reason='windows has no concept of execute permissions')
+    @pytest.mark.skipif(
+        os.name == "nt", reason="windows has no concept of execute permissions"
+    )
     def test_archive_permissions(self, sp):
         with tempfile.TemporaryDirectory() as tmpdir:
-            target = Path(tmpdir, 'test.zip')
-            create_archive(sp, target, sys.executable, 'code:interact')
+            target = Path(tmpdir, "test.zip")
+            create_archive(sp, target, sys.executable, "code:interact")
 
             assert target.stat().st_mode & UGOX == UGOX

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -45,12 +45,13 @@ class TestCLI:
         # assert we got the correct reason
         assert strip_header(result.output) == DISALLOWED_PIP_ARGS.format(arg=arg, reason=reason)
 
-    def test_hello_world(self, tmpdir, runner, package_location):
+    @pytest.mark.parametrize('compile_option', ["--compile-pyc", "--no-compile-pyc"])
+    def test_hello_world(self, tmpdir, runner, package_location, compile_option):
 
         with tempfile.TemporaryDirectory(dir=tmpdir) as tmpdir:
             output_file = Path(tmpdir, 'test.pyz')
 
-            result = runner(['-e', 'hello:main', '-o', str(output_file), str(package_location)])
+            result = runner(['-e', 'hello:main', '-o', str(output_file), str(package_location), compile_option])
 
             # check that the command successfully completed
             assert result.exit_code == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py36, py37
 
 [testenv]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
fixes #54

This change adds a `--compile-pyc/--no-compile-pyc` command line argument that enables (the default) or disable the compilation of pyc files during initial bootstrap.

it also adds an environment variable to do the same. 

(the diff is a little large because there's a handful of cosmetic changes as well)