### PR TITLE
#57 add ability to execute as a module

### DIFF
--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -154,3 +154,7 @@ def main(
 
     if not quiet:
         click.secho(" done ", bold=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
python 3.6 tests don't work on my mac because of some weird unicode encoding thing, but 3.7 works fine. 