### PR TITLE
Adds ability use existing site-packages in zipapp

### DIFF
--- a/src/shiv/constants.py
+++ b/src/shiv/constants.py
@@ -3,7 +3,7 @@ from typing import Tuple, Dict
 
 # errors:
 DISALLOWED_PIP_ARGS = "\nYou supplied a disallowed pip argument! '{arg}'\n\n{reason}\n"
-NO_PIP_ARGS = "\nYou must supply PIP ARGS!\n"
+NO_PIP_ARGS_OR_SITE_PACKAGES = "\nYou must supply PIP ARGS or --site-packages!\n"
 NO_OUTFILE = "\nYou must provide an output file option! (--output-file/-o)\n"
 NO_ENTRY_POINT = "\nNo entry point '{entry_point}' found in the console_scripts!\n"
 PIP_INSTALL_ERROR = "\nPip install failed!\n"

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -9,7 +9,7 @@ import pytest
 from click.testing import CliRunner
 
 from shiv.cli import main
-from shiv.constants import DISALLOWED_PIP_ARGS, NO_PIP_ARGS, NO_OUTFILE, BLACKLISTED_ARGS
+from shiv.constants import DISALLOWED_PIP_ARGS, NO_PIP_ARGS_OR_SITE_PACKAGES, NO_OUTFILE, BLACKLISTED_ARGS
 
 
 def strip_header(output):
@@ -24,7 +24,7 @@ class TestCLI:
     def test_no_args(self, runner):
         result = runner([])
         assert result.exit_code == 1
-        assert strip_header(result.output) == NO_PIP_ARGS
+        assert strip_header(result.output) == NO_PIP_ARGS_OR_SITE_PACKAGES
 
     def test_no_outfile(self, runner):
         result = runner(['-e', 'test', 'flask'])


### PR DESCRIPTION
The optional `--site-packages` flag can be passed an existing site-packages
directory which will be copied into the final zipapp. It can be used in
addition to `pip_args` or without any `pip_args` at all. Examples:

```
shiv -o myapp.pyz \
    --site-packages=/path/to/venv/lib/python3.7/site-packages
shiv -o myapp.pyz \
    --site-packages=/path/to/venv/lib/python3.7/site-packages \
    --no-deps myapp
```