### PR TITLE
Accomodate Debian's Python packaging

### DIFF
--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -85,7 +85,7 @@ def extract_site_packages(archive, target_path, compile_pyc, compile_workers=0):
 
 def _first_sitedir_index():
     for index, part in enumerate(sys.path):
-        if Path(part).stem == "site-packages":
+        if Path(part).stem in ["site-packages", "dist-packages"]:
             return index
 
 


### PR DESCRIPTION
Debian also uses `dist-packages`. See https://github.com/pypa/virtualenv/blob/c8e8029246d8bd8db82ddbfdfc7238940eb19102/virtualenv_embedded/site.py#L252-L264 for an example.