### PR TITLE
Adds ability to toggle system site package inclusion in runtime

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,6 +89,13 @@ SHIV_INTERPRETER
 This is a boolean that bypasses and console_script or entry point baked into your pyz. Useful for
 dropping into an interactive session in the environment of a built cli utility.
 
+SHIV_SYSTEM_SITE_PACKAGES
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is a boolean that toggles the inclusion of system site packages in the runtime environment
+for your pyz. The default is `False` (don't include system site packages), unless enabled during
+shiv's build process.
+
 SHIV_ENTRY_POINT
 ^^^^^^^^^^^^^^^^
 

--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -85,7 +85,7 @@ def extract_site_packages(archive, target_path, compile_pyc, compile_workers=0):
 
 def _first_sitedir_index():
     for index, part in enumerate(sys.path):
-        if Path(part).stem == "site-packages":
+        if Path(part).stem in ["site-packages", "dist-packages"]:
             return index
 
 

--- a/src/shiv/bootstrap/environment.py
+++ b/src/shiv/bootstrap/environment.py
@@ -21,6 +21,7 @@ class Environment:
     ROOT = "SHIV_ROOT"
     FORCE_EXTRACT = "SHIV_FORCE_EXTRACT"
     COMPILE_PYC = "SHIV_COMPILE_PYC"
+    SYSTEM_SITE_PACKAGES = "SHIV_SYSTEM_SITE_PACKAGES"
     COMPILE_WORKERS = "SHIV_COMPILE_WORKERS"
 
     def __init__(
@@ -29,6 +30,7 @@ class Environment:
         entry_point=None,
         always_write_cache=False,
         compile_pyc=True,
+        system_site_packages=False,
     ):
         self.build_id = build_id
         self.always_write_cache = always_write_cache
@@ -36,6 +38,7 @@ class Environment:
         # properties
         self._entry_point = entry_point
         self._compile_pyc = compile_pyc
+        self._system_site_packages = system_site_packages
 
     @classmethod
     def from_json(cls, json_data):
@@ -69,6 +72,12 @@ class Environment:
     @property
     def compile_pyc(self):
         return str_bool(os.environ.get(self.COMPILE_PYC, self._compile_pyc))
+
+    @property
+    def system_site_packages(self):
+        return str_bool(
+            os.environ.get(self.SYSTEM_SITE_PACKAGES, self._system_site_packages)
+        )
 
     @property
     def compile_workers(self):

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -85,6 +85,11 @@ def copy_bootstrap(bootstrap_target: Path) -> None:
     default=True,
     help="Whether or not to compile pyc files during initial bootstrap.",
 )
+@click.option(
+    "--system-site-packages/--no-system-site-packages",
+    default=False,
+    help="Inherit system site packages during runtime",
+)
 @click.argument("pip_args", nargs=-1, type=click.UNPROCESSED)
 def main(
     output_file: str,
@@ -94,6 +99,7 @@ def main(
     site_packages: Optional[str],
     compressed: bool,
     compile_pyc: bool,
+    system_site_packages: bool,
     pip_args: List[str],
 ) -> None:
     """
@@ -140,7 +146,10 @@ def main(
 
         # create runtime environment metadata
         env = Environment(
-            build_id=str(uuid.uuid4()), entry_point=entry_point, compile_pyc=compile_pyc
+            build_id=str(uuid.uuid4()),
+            entry_point=entry_point,
+            compile_pyc=compile_pyc,
+            system_site_packages=system_site_packages,
         )
 
         Path(working_path, "environment.json").write_text(env.to_json())


### PR DESCRIPTION
This makes the zipapps work a little more like virtualenv. It uses the same default as virtualenv (no system site packages) which is not backwards compatible. To retain the current functionality, you can build with the `--system-site-packages` flag or add `SHIV_SYSTEM_SITE_PACKAGES=True` during runtime.

Original issue: #65
Includes #64 since this is related
