### PR TITLE
Ensure pip subprocess has appropriate path

### DIFF
--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -86,14 +86,14 @@ def extract_site_packages(archive, target_path, compile_pyc, compile_workers=0):
 
 def _first_sitedir_index():
     for index, part in enumerate(sys.path):
-        if Path(part).stem in ["site-packages", "dist-packages"]:
+        if Path(part).stem in ("site-packages", "dist-packages"):
             return index
 
 
-def _extend_python_path(additional_paths):
-    python_path = os.environ["PYTHONPATH"].split(os.pathsep) if "PYTHONPATH" in os.environ else []
+def _extend_python_path(environ, additional_paths):
+    python_path = environ["PYTHONPATH"].split(os.pathsep) if "PYTHONPATH" in environ else []
     python_path.extend(additional_paths)
-    os.environ["PYTHONPATH"] = os.pathsep.join(python_path)
+    environ["PYTHONPATH"] = os.pathsep.join(python_path)
 
 
 def bootstrap():
@@ -124,7 +124,7 @@ def bootstrap():
 
     # add our site-packages to the environment, if requested
     if env.extend_pythonpath:
-        _extend_python_path(sys.path[index:])
+        _extend_python_path(os.environ, sys.path[index:])
 
     # reorder to place our site-packages before any others found
     sys.path = sys.path[:index] + sys.path[length:] + sys.path[index:length]

--- a/src/shiv/pip.py
+++ b/src/shiv/pip.py
@@ -5,6 +5,9 @@ import sys
 
 from typing import Generator, List
 
+import click
+
+from .bootstrap import _first_sitedir_index, _extend_python_path
 from .constants import PIP_REQUIRE_VIRTUALENV, PIP_INSTALL_ERROR
 
 
@@ -42,15 +45,23 @@ def install(args: List[str]) -> None:
     """
     with clean_pip_env():
 
+        # if being invoked as a pyz, we must ensure we have access to our own
+        # site-packages when subprocessing since there is no guarantee that pip
+        # will be available
+        subprocess_env = os.environ.copy()
+        sitedir_index = _first_sitedir_index()
+        _extend_python_path(subprocess_env, sys.path[sitedir_index:])
+
         process = subprocess.Popen(
             [sys.executable, "-m", "pip", "--disable-pip-version-check", "install"] + args,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            env=subprocess_env,
         )
 
         for output in process.stdout:
             if output:
-                print(output.decode().rstrip())
+                click.echo(output.decode().rstrip())
 
         if process.wait() > 0:
             sys.exit(PIP_INSTALL_ERROR)

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -93,12 +93,10 @@ class TestBootstrap:
     @pytest.mark.parametrize("additional_paths", (["test"], ["test", ".pth"]))
     def test_extend_path(self, additional_paths):
 
-        orig = os.environ.copy()
+        env = os.environ.copy()
 
-        _extend_python_path(additional_paths)
-        assert os.environ["PYTHONPATH"] == os.pathsep.join(additional_paths)
-
-        os.environ = orig
+        _extend_python_path(env, additional_paths)
+        assert env["PYTHONPATH"] == os.pathsep.join(additional_paths)
 
 
 class TestEnvironment:


### PR DESCRIPTION
So, we specify that `pip` is a dependency, but if someone creates a `pyz` of `shiv` using `shiv`, the subprocess call to `python3 -m pip` may fail in environments where pip isn't installed globally.

This change ensures that the subprocess call includes shiv's site-packages as a PYTHONPATH variable. I tested this manually and it works well.