### PR TITLE
add more metadata to Environment & a simple "shiv-info" util

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,7 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             'shiv = shiv.cli:main',
+            'shiv-info = shiv.info:main',
         ],
     },
     include_package_data=True,

--- a/src/shiv/bootstrap/environment.py
+++ b/src/shiv/bootstrap/environment.py
@@ -26,6 +26,8 @@ class Environment:
 
     def __init__(
         self,
+        built_at,
+        shiv_version,
         build_id=None,
         entry_point=None,
         script=None,
@@ -33,6 +35,8 @@ class Environment:
         compile_pyc=True,
         extend_pythonpath=False,
     ):
+        self.built_at = built_at
+        self.shiv_version = shiv_version
         self.build_id = build_id
         self.always_write_cache = always_write_cache
         self.script = script

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -8,6 +8,7 @@ except ImportError:
     import importlib_resources  # type: ignore
 
 from configparser import ConfigParser
+from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Optional, List, no_type_check
@@ -178,11 +179,13 @@ def main(
 
         # create runtime environment metadata
         env = Environment(
+            built_at=str(datetime.now()),
             build_id=str(uuid.uuid4()),
             entry_point=entry_point,
             script=console_script,
             compile_pyc=compile_pyc,
             extend_pythonpath=extend_pythonpath,
+            shiv_version=__version__,
         )
 
         Path(working_path, "environment.json").write_text(env.to_json())

--- a/src/shiv/info.py
+++ b/src/shiv/info.py
@@ -1,0 +1,28 @@
+import click
+import json
+import zipfile
+
+
+@click.command(context_settings=dict(help_option_names=["-h", "--help", "--halp"]))
+@click.option("--json", "-j", "print_as_json", is_flag=True, help="output as plain json")
+@click.argument("pyz")
+def main(print_as_json, pyz):
+    """A simple utility to print debugging information about PYZ files created with ``shiv``"""
+
+    zip_file = zipfile.ZipFile(pyz)
+    data = json.loads(zip_file.read("environment.json"))
+
+    if print_as_json:
+        click.echo(json.dumps(data, indent=4, sort_keys=True))
+
+    else:
+        click.echo()
+        click.secho(f"pyz file: ", fg="green", bold=True, nl=False)
+        click.secho(pyz, fg="white")
+        click.echo()
+
+        for key, value in data.items():
+            click.secho(f"{key}: ", fg="blue", bold=True, nl=False)
+            click.secho(f"{value}", fg="white")
+
+        click.echo()

--- a/src/shiv/pip.py
+++ b/src/shiv/pip.py
@@ -43,6 +43,7 @@ def install(args: List[str]) -> None:
         Successfully installed numpy-1.13.3
 
     """
+
     with clean_pip_env():
 
         # if being invoked as a pyz, we must ensure we have access to our own
@@ -53,15 +54,15 @@ def install(args: List[str]) -> None:
         _extend_python_path(subprocess_env, sys.path[sitedir_index:])
 
         process = subprocess.Popen(
-            [sys.executable, "-m", "pip", "--disable-pip-version-check", "install"] + args,
+            [sys.executable, "-m", "pip", "--disable-pip-version-check", "install", *args],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=subprocess_env,
         )
 
-        for output in process.stdout:
-            if output:
-                click.echo(output.decode().rstrip())
+    for output in process.stdout:
+        if output:
+            click.echo(output.decode().rstrip())
 
-        if process.wait() > 0:
-            sys.exit(PIP_INSTALL_ERROR)
+    if process.wait() > 0:
+        sys.exit(PIP_INSTALL_ERROR)

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 from site import addsitedir
 from code import interact
@@ -112,7 +113,12 @@ class TestBootstrap:
 
 class TestEnvironment:
     def test_overrides(self):
-        env = Environment()
+        now = str(datetime.now())
+        version = "0.0.1"
+        env = Environment(now, version)
+
+        assert env.built_at == now
+        assert env.shiv_version == version
 
         assert env.entry_point is None
         with env_var('SHIV_ENTRY_POINT', 'test'):
@@ -147,7 +153,9 @@ class TestEnvironment:
             assert env.compile_workers == 0
 
     def test_roundtrip(self):
-        env = Environment()
+        now = str(datetime.now())
+        version = "0.0.1"
+        env = Environment(now, version)
         env_as_json = env.to_json()
         env_from_json = Environment.from_json(env_as_json)
         assert env.__dict__ == env_from_json.__dict__


### PR DESCRIPTION
```
(shiv) linux ~/src/shiv git:shiv-info ✓ $ shiv-info ~/r.pyz

pyz file: /home/lcarvalh/r.pyz

shiv_version: 0.0.41
built_at: 2018-12-21 13:08:43.361620
build_id: e1c61855-429d-4a33-9751-f0f6e9800834
always_write_cache: False
entry_point: None
compile_pyc: True
extend_pythonpath: False

(shiv) linux ~/src/shiv git:shiv-info ✓ $ shiv-info ~/r.pyz --json
{
    "always_write_cache": false,
    "build_id": "e1c61855-429d-4a33-9751-f0f6e9800834",
    "built_at": "2018-12-21 13:08:43.361620",
    "compile_pyc": true,
    "entry_point": null,
    "extend_pythonpath": false,
    "shiv_version": "0.0.41"
}
```