### PR TITLE
Add support for bare scripts.

### DIFF
--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -1,5 +1,6 @@
 import compileall
 import os
+import runpy
 import site
 import sys
 import shutil
@@ -139,9 +140,12 @@ def bootstrap():
             # callable shares a name with it's parent module
             # e.g. "from foo.bar import bar; bar()"
             sys.exit(getattr(mod, env.entry_point.replace(":", ".").split(".")[1])())
-    else:
-        # drop into interactive mode
-        execute_interpreter()
+
+    elif env.script is not None:
+        sys.exit(runpy.run_path(site_packages / "bin" / env.script, run_name="__main__"))
+
+    # all other options exhausted, drop into interactive mode
+    execute_interpreter()
 
 
 if __name__ == "__main__":

--- a/src/shiv/bootstrap/environment.py
+++ b/src/shiv/bootstrap/environment.py
@@ -28,12 +28,14 @@ class Environment:
         self,
         build_id=None,
         entry_point=None,
+        script=None,
         always_write_cache=False,
         compile_pyc=True,
         extend_pythonpath=False,
     ):
         self.build_id = build_id
         self.always_write_cache = always_write_cache
+        self.script = script
 
         # properties
         self._entry_point = entry_point

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -171,13 +171,16 @@ def main(
         if entry_point is None and console_script is not None:
             try:
                 entry_point = find_entry_point(tmp_site_packages, console_script)
+
             except KeyError:
-                sys.exit(NO_ENTRY_POINT.format(entry_point=console_script))
+                if not Path(tmp_site_packages, "bin", console_script).exists():
+                    sys.exit(NO_ENTRY_POINT.format(entry_point=console_script))
 
         # create runtime environment metadata
         env = Environment(
             build_id=str(uuid.uuid4()),
             entry_point=entry_point,
+            script=console_script,
             compile_pyc=compile_pyc,
             extend_pythonpath=extend_pythonpath,
         )

--- a/src/shiv/constants.py
+++ b/src/shiv/constants.py
@@ -5,7 +5,7 @@ from typing import Tuple, Dict
 DISALLOWED_PIP_ARGS = "\nYou supplied a disallowed pip argument! '{arg}'\n\n{reason}\n"
 NO_PIP_ARGS_OR_SITE_PACKAGES = "\nYou must supply PIP ARGS or --site-packages!\n"
 NO_OUTFILE = "\nYou must provide an output file option! (--output-file/-o)\n"
-NO_ENTRY_POINT = "\nNo entry point '{entry_point}' found in the console_scripts!\n"
+NO_ENTRY_POINT = "\nNo entry point '{entry_point}' found in console_scripts or the bin dir!\n"
 PIP_INSTALL_ERROR = "\nPip install failed!\n"
 BINPRM_ERROR = "\nShebang is too long, it would exceed BINPRM_BUF_SIZE! Consider /usr/bin/env"
 


### PR DESCRIPTION
Some Python packages use scripts instead of callables as their primary entry point, this PR adds support for that in pyz's created with shiv.

for example:

before
```
linux ~ $ shiv -c ansible ansible -o ansible -q

No entry point 'ansible' found in the console_scripts!
```

after
```
(shiv) linux ~ $ shiv -c ansible ansible -o ansible -q
(shiv) linux ~ $ ./ansible --version
ansible 2.7.5
  config file = None
  configured module search path = ['/home/lcarvalh/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/lcarvalh/.shiv/ansible_3b8a34e5-27e6-420a-b02f-4c1a33a4796b/site-packages/ansible
  executable location = /home/lcarvalh/.shiv/ansible_3b8a34e5-27e6-420a-b02f-4c1a33a4796b/site-packages/bin/ansible
  python version = 3.7.0 (default, Aug 11 2018, 03:49:56) [GCC 4.4.7 20120313 (Red Hat 4.4.7-17)]
```