### PR TITLE
Restore original permissions during extraction.

### DIFF
--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -107,9 +107,13 @@ def extract_site_packages(archive, target_path, compile_pyc, compile_workers=0, 
         if not target_path.exists() or force:
 
             # extract our site-packages
-            for filename in archive.namelist():
-                if filename.startswith("site-packages"):
-                    archive.extract(filename, target_path_tmp)
+            for fileinfo in archive.infolist():
+
+                if fileinfo.filename.startswith("site-packages"):
+                    extracted = archive.extract(fileinfo.filename, target_path_tmp)
+
+                    # restore original permissions
+                    os.chmod(extracted, fileinfo.external_attr >> 16)
 
             if compile_pyc:
                 compileall.compile_dir(target_path_tmp, quiet=2, workers=compile_workers)

--- a/test/package/hello/script.sh
+++ b/test/package/hello/script.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 0

--- a/test/package/setup.py
+++ b/test/package/setup.py
@@ -5,5 +5,6 @@ import setuptools
 setup(
     name='hello',
     packages=['hello'],
+    package_data={'': ['script.sh']},
     entry_points={"console_scripts": ["hello = hello:main"]},
 )

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -12,7 +12,7 @@ from zipfile import ZipFile
 
 import pytest
 
-from shiv.bootstrap import _extend_python_path, _first_sitedir_index, cache_path, current_zipfile, extract_site_packages, import_string, run
+from shiv.bootstrap import _extend_python_path, _first_sitedir_index, cache_path, current_zipfile, extract_site_packages, import_string
 from shiv.bootstrap.environment import Environment
 from shiv.bootstrap.filelock import FileLock
 
@@ -157,8 +157,3 @@ class TestEnvironment:
             assert f.is_locked
 
         assert not f.is_locked
-
-    def scrub_env(self):
-
-        with mock.patch('sys.exit'):
-            run(lambda: 1)


### PR DESCRIPTION
This ought to fix #100 

```
(shiv) darwin ~/src/shiv git:master ✓ $ shiv -c psautohint psautohint -o ~/before -q
(shiv) darwin ~/src/shiv git:master ✓ $ git checkout restore_executable_bit
Switched to branch 'restore_executable_bit'
(shiv) darwin ~/src/shiv git:restore_executable_bit ✓ $ shiv -c psautohint psautohint -o ~/after -q
(shiv) darwin ~/src/shiv git:restore_executable_bit ✓ $ ~/before --version
/Users/lcarvalh/.shiv/before_f71fbdb8-4b05-4fc1-97f9-a831867463cb/site-packages/psautohint/__init__.py:24: UserWarning: embedded 'autohintexe' executable not found: '/Users/lcarvalh/.shiv/before_f71fbdb8-4b05-4fc1-97f9-a831867463cb/site-packages/psautohint/autohintexe'
  "embedded 'autohintexe' executable not found: %r" % AUTOHINTEXE
1.9.2
(shiv) darwin ~/src/shiv git:restore_executable_bit ✓ $ ~/after --version
1.9.2
```

todo: add a test
