### PR TITLE
Fix for UnicodeDecodeError when having unicode character in folder path

### DIFF
--- a/src/shiv/pip.py
+++ b/src/shiv/pip.py
@@ -54,15 +54,23 @@ def install(args: List[str]) -> None:
         _extend_python_path(subprocess_env, sys.path[sitedir_index:])
 
         process = subprocess.Popen(
-            [sys.executable, "-m", "pip", "--disable-pip-version-check", "install", *args],
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "--disable-pip-version-check",
+                "install",
+                *args,
+            ],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=subprocess_env,
+            text=True,
         )
 
     for output in process.stdout:
         if output:
-            click.echo(output.decode().rstrip())
+            click.echo(output.rstrip())
 
     if process.wait() > 0:
         sys.exit(PIP_INSTALL_ERROR)

--- a/src/shiv/pip.py
+++ b/src/shiv/pip.py
@@ -65,7 +65,7 @@ def install(args: List[str]) -> None:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=subprocess_env,
-            text=True,
+            universal_newlines=True,
         )
 
     for output in process.stdout:


### PR DESCRIPTION
Original issue #110 
This PR makes it possible to have unicode characters in the folder path. 

If the project path is for example C:\lösningar\energi, **shiv**, at its current state, throw the exception below. 
```python
Traceback (most recent call last):
  File "c:\programdata\miniconda3\envs\energi_xl\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\programdata\miniconda3\envs\energi_xl\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\ProgramData\Miniconda3\envs\energi_xl\Scripts\shiv.exe\__main__.py", line 9, in <module>
  File "c:\programdata\miniconda3\envs\energi_xl\lib\site-packages\click\core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "c:\programdata\miniconda3\envs\energi_xl\lib\site-packages\click\core.py", line 697, in main
    rv = self.invoke(ctx)
  File "c:\programdata\miniconda3\envs\energi_xl\lib\site-packages\click\core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\programdata\miniconda3\envs\energi_xl\lib\site-packages\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "c:\programdata\miniconda3\envs\energi_xl\lib\site-packages\shiv\cli.py", line 169, in main
    pip.install(["--target", str(tmp_site_packages)] + list(pip_args))
  File "c:\programdata\miniconda3\envs\energi_xl\lib\site-packages\shiv\pip.py", line 65, in install
    click.echo(output.decode().rstrip())
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf6 in position 15: invalid start byte
```