### PR TITLE
Avoid copying of site-packages directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ activate
 *.iml
 *.ipr
 *.iws
+
+# VS Code
+/.vscode

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from shiv.bootstrap.environment import Environment
+
 
 @pytest.fixture
 def zip_location():
@@ -27,4 +29,17 @@ def package_location(request):
 
 @pytest.fixture
 def sp():
-    return Path(__file__).absolute().parent / "sp" / "site-packages"
+    return Path(__file__).absolute().parent / 'sp' / 'site-packages'
+
+
+@pytest.fixture
+def env():
+    return Environment(
+        built_at=str("2019-01-01 12:12:12"),
+        build_id=str("test_id"),
+        entry_point="test_entry_point",
+        script="test_console_script",
+        compile_pyc=False,
+        extend_pythonpath=False,
+        shiv_version="0.0.1",
+    )

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -39,25 +39,25 @@ class TestBuilder:
         with pytest.raises(SystemExit):
             tmp_write_prefix(f"/{'c' * 200}/python")
 
-    def test_create_archive(self, sp):
+    def test_create_archive(self, sp, env):
         with tempfile.TemporaryDirectory() as tmpdir:
             target = Path(tmpdir, "test.zip")
 
             # create an archive
-            create_archive(sp, target, sys.executable, "code:interact")
+            create_archive(sp, target, sys.executable, "code:interact", env)
 
             # create one again (to ensure we overwrite)
-            create_archive(sp, target, sys.executable, "code:interact")
+            create_archive(sp, target, sys.executable, "code:interact", env)
 
             assert zipfile.is_zipfile(str(target))
 
             with pytest.raises(ZipAppError):
-                create_archive(sp, target, sys.executable, "alsjdbas,,,")
+                create_archive(sp, target, sys.executable, "alsjdbas,,,", env)
 
     @pytest.mark.skipif(os.name == "nt", reason="windows has no concept of execute permissions")
-    def test_archive_permissions(self, sp):
+    def test_archive_permissions(self, sp, env):
         with tempfile.TemporaryDirectory() as tmpdir:
             target = Path(tmpdir, "test.zip")
-            create_archive(sp, target, sys.executable, "code:interact")
+            create_archive(sp, target, sys.executable, "code:interact", env)
 
             assert target.stat().st_mode & UGOX == UGOX


### PR DESCRIPTION
Currently, when you provide shiv CLI a site-packages directory to include into a zip file, it will first copy this directory to a temporary destination and then package this temporary destination into an archive. This action is redundant and costs us several seconds for each invocation for the 100MB virtual environment. 2-3 seconds may seem not important but it sums up on a scale of thousands of invocations per day. 

This PR introduces the solution to this problem by avoiding the temporary destination and copying site-packages directly to the final archive.

Testing done:

* added two unit-test for the new method;
* ensured that all the tests and other checks pass;
* manually compared the zipapps produced by shiv before and after this change and verified they are similar.

P.S. Sorry for not creating an issue first. I already prepared the PR when I saw contributing guidelines.