### PR TITLE
fix 'dir already exists' when supplying both pip_args and site_packages

### DIFF
--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -127,7 +127,7 @@ def main(
                 # the dst dir arg to shutil.copytree must not exist, so tack on a non-existant directory here. Starting
                 # with python 3.8 this can be removed and shutil.copytree called with dirs_exist_ok=True to work around this
                 tmp_site_packages = Path(tmp_site_packages, "site_packages")
-                shutil.copytree(site_packages, tmp_site_packages)
+                shutil.copytree(site_packages, str(tmp_site_packages))
             else:
                 tmp_site_packages = site_packages
 

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -124,7 +124,10 @@ def main(
         # dir into our staging area (tmp_site_packages) as pip may modify the contents.
         if site_packages:
             if pip_args:
-                shutil.copytree(site_packages, tmp_site_packages, dirs_exist_ok=True)
+                # the dst dir arg to shutil.copytree must not exist, so tack on a non-existant directory here. Starting
+                # with python 3.8 this can be removed and shutil.copytree called with dirs_exist_ok=True to work around this
+                tmp_site_packages = Path(tmp_site_packages, "site_packages")
+                shutil.copytree(site_packages, tmp_site_packages
             else:
                 tmp_site_packages = site_packages
 

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -124,7 +124,7 @@ def main(
         # dir into our staging area (tmp_site_packages) as pip may modify the contents.
         if site_packages:
             if pip_args:
-                shutil.copytree(site_packages, tmp_site_packages)
+                shutil.copytree(site_packages, tmp_site_packages, dirs_exist_ok=True)
             else:
                 tmp_site_packages = site_packages
 

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -127,7 +127,7 @@ def main(
                 # the dst dir arg to shutil.copytree must not exist, so tack on a non-existant directory here. Starting
                 # with python 3.8 this can be removed and shutil.copytree called with dirs_exist_ok=True to work around this
                 tmp_site_packages = Path(tmp_site_packages, "site_packages")
-                shutil.copytree(site_packages, tmp_site_packages
+                shutil.copytree(site_packages, tmp_site_packages)
             else:
                 tmp_site_packages = site_packages
 


### PR DESCRIPTION
This happens when i run shiv to package the current python project as well as the dependencies. I am running shiv like below and seeing this error without this change.

I am not totally sure how to create a test for this.

```
source /home/jarekr/venv/_tools_env/bin/activate && shiv -e we.cli:we -o dist/wep.linux . -E --python "/usr/local/bin/python3 -I" --site-packages venv/we-tools-py-linux/lib/python3.7/site-packages
Traceback (most recent call last):
  File "/home/jarekr/venv/_tools_env/bin/shiv", line 11, in <module>
    sys.exit(main())
  File "/home/jarekr/venv/_tools_env/lib/python3.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/jarekr/venv/_tools_env/lib/python3.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/jarekr/venv/_tools_env/lib/python3.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jarekr/venv/_tools_env/lib/python3.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/jarekr/venv/_tools_env/lib/python3.7/site-packages/shiv/cli.py", line 127, in main
    shutil.copytree(site_packages, tmp_site_packages)
  File "/usr/local/lib/python3.7/shutil.py", line 321, in copytree
    os.makedirs(dst)
  File "/usr/local/lib/python3.7/os.py", line 221, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/tmp/tmpuebw1ewo'
make: *** [build] Error 1
```