### PR TITLE
Support including multiple site-packages directories into shiv

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,7 @@
 shiv 🔪
 ====================
 
-Shiv is a command line utility for building fully self
-contained Python zipapps as outlined in `PEP 441 <http://legacy.python.org/dev/peps/pep-0441/>`_
+Shiv is a command line utility for building fully self-contained Python zipapps as outlined in `PEP 441 <http://legacy.python.org/dev/peps/pep-0441/>`_
 but with all their dependencies included!
 
 Shiv's primary goal is making distributing Python applications fast & easy.
@@ -23,7 +22,7 @@ In order to build self-contained single-artifact executables, shiv leverages ``p
     dependencies into the resulting binary, and then at bootstrap time extracts it into a ``~/.shiv``
     cache directory. More on this in the `Bootstrapping` section.
 
-shiv accepts only a few command line parameters of it's own, and any unprocessed parameters are
+shiv accepts only a few command line parameters of its own, and any unprocessed parameters are
 delegated to ``pip install``.
 
 For example, if you wanted to create an executable for Pipenv, you'd specify the required
@@ -58,7 +57,7 @@ environment, since the ``pyz`` files can be used as a shebang!
 Bootstrapping
 ^^^^^^^^^^^^^
 
-When you run an executable created with shiv a special bootstrap function is called. This function
+When you run an executable created with shiv, a special bootstrap function is called. This function
 unpacks dependencies into a uniquely named subdirectory of ``~/.shiv`` and then runs your entry point
 (or interactive interpreter) with those dependencies added to your ``sys.path``. Once the
 dependencies have been extracted to disk, any further invocations will re-use the 'cached'

--- a/src/shiv/builder.py
+++ b/src/shiv/builder.py
@@ -11,7 +11,7 @@ import zipapp
 import zipfile
 
 from pathlib import Path
-from typing import IO, Any, Generator, Union
+from typing import IO, Any, Generator, List, Union
 
 from . import bootstrap
 from .bootstrap.environment import Environment
@@ -57,7 +57,7 @@ def maybe_open(archive: Union[str, Path], mode: str) -> Generator[IO[Any], None,
 
 
 def create_archive(
-    source: Path, target: Path, interpreter: str, main: str, env: Environment, compressed: bool = True
+    sources: List[Path], target: Path, interpreter: str, main: str, env: Environment, compressed: bool = True
 ) -> None:
     """Create an application archive from SOURCE.
 
@@ -85,20 +85,20 @@ def create_archive(
 
         # Pack zipapp with dependencies.
         with zipfile.ZipFile(fd, "w", compression=compression) as z:
-
             site_packages = Path("site-packages")
 
-            # Glob is known to return results in undetermenistic order.
-            # We need to sort them by in-archive paths to ensure
-            # that archive contents are reproducible.
-            for child in sorted(source.rglob("*"), key=str):
+            for source in sources:
+                # Glob is known to return results in undetermenistic order.
+                # We need to sort them by in-archive paths to ensure
+                # that archive contents are reproducible.
+                for child in sorted(source.rglob("*"), key=str):
 
-                # Skip compiled files.
-                if child.suffix == ".pyc":
-                    continue
+                    # Skip compiled files.
+                    if child.suffix == ".pyc":
+                        continue
 
-                arcname = site_packages / child.relative_to(source)
-                z.write(child, arcname)
+                    arcname = site_packages / child.relative_to(source)
+                    z.write(child, arcname)
 
             bootstrap_target = Path("_bootstrap")
 

--- a/src/shiv/builder.py
+++ b/src/shiv/builder.py
@@ -4,18 +4,21 @@ This module is a modified implementation of Python's "zipapp" module.
 We've copied a lot of zipapp's code here in order to backport support for compression.
 https://docs.python.org/3.7/library/zipapp.html#cmdoption-zipapp-c
 """
-import contextlib
+import hashlib
+import os
 import stat
 import sys
+import time
 import zipapp
 import zipfile
 
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import IO, Any, Generator, List, Union
+from typing import IO, Any, List, Optional, Tuple, Union
 
 from . import bootstrap
 from .bootstrap.environment import Environment
-from .constants import BINPRM_ERROR
+from .constants import BINPRM_ERROR, BUILD_AT_TIMESTAMP_FORMAT
 
 try:
     import importlib.resources as importlib_resources  # type: ignore
@@ -46,14 +49,35 @@ def write_file_prefix(f: IO[Any], interpreter: str) -> None:
     f.write(b"#!" + interpreter.encode(sys.getfilesystemencoding()) + b"\n")
 
 
-@contextlib.contextmanager
-def maybe_open(archive: Union[str, Path], mode: str) -> Generator[IO[Any], None, None]:
-    if isinstance(archive, (str, Path)):
-        with Path(archive).open(mode=mode) as f:
-            yield f
+def _write_to_zip_app(
+    arhive: zipfile.ZipFile,
+    arcname: str,
+    data_source: Union[Path, bytes],
+    date_time: Tuple[int, int, int, int, int, int],
+    compression: int,
+    contents_hash: hashlib.sha3_256,
+) -> None:
+    """Write a file or a bytestring to a ZipFile as a separate entry and
+    update contents_hash as a side effect
 
+    The approach is borrowed from 'wheel' code.
+    """
+    if isinstance(data_source, Path):
+        with data_source.open('rb') as f:
+            data = f.read()
+            st: Optional[os.stat_result] = os.fstat(f.fileno())
     else:
-        yield archive
+        data = data_source
+        st = None
+
+    contents_hash.update(data)
+
+    zinfo = zipfile.ZipInfo(arcname, date_time=date_time)
+    zinfo.compress_type = compression
+    if st is not None:
+        zinfo.external_attr = (stat.S_IMODE(st.st_mode) | stat.S_IFMT(st.st_mode)) << 16
+
+    arhive.writestr(zinfo, data)
 
 
 def create_archive(
@@ -74,8 +98,11 @@ def create_archive(
         raise zipapp.ZipAppError("Invalid entry point: " + main)
 
     main_py = MAIN_TEMPLATE.format(module=mod, fn=fn)
+    timestamp = datetime.strptime(env.built_at, BUILD_AT_TIMESTAMP_FORMAT).replace(tzinfo=timezone.utc).timestamp()
+    zipinfo_datetime: Tuple[int, int, int, int, int, int] = time.gmtime(int(timestamp))[0:6]
+    contents_hash = hashlib.sha256()
 
-    with maybe_open(target, "wb") as fd:
+    with target.open(mode="wb") as fd:
 
         # Write shebang.
         write_file_prefix(fd, interpreter)
@@ -92,13 +119,12 @@ def create_archive(
                 # We need to sort them by in-archive paths to ensure
                 # that archive contents are reproducible.
                 for child in sorted(source.rglob("*"), key=str):
-
-                    # Skip compiled files.
-                    if child.suffix == ".pyc":
+                    # Skip compiled files and directories
+                    if child.suffix == ".pyc" or child.is_dir():
                         continue
 
-                    arcname = site_packages / child.relative_to(source)
-                    z.write(child, arcname)
+                    arcname = str(site_packages / child.relative_to(source))
+                    _write_to_zip_app(z, arcname, child, zipinfo_datetime, compression, contents_hash)
 
             bootstrap_target = Path("_bootstrap")
 
@@ -106,13 +132,21 @@ def create_archive(
             for bootstrap_file in importlib_resources.contents(bootstrap):  # type: ignore
                 if importlib_resources.is_resource(bootstrap, bootstrap_file):  # type: ignore
                     with importlib_resources.path(bootstrap, bootstrap_file) as f:  # type: ignore
-                        z.write(f.absolute(), bootstrap_target / f.name)
+                        _write_to_zip_app(z, str(bootstrap_target / f.name), f.absolute(), zipinfo_datetime,
+                                          compression, contents_hash)
 
-            # write environment
-            z.writestr("environment.json", env.to_json().encode("utf-8"))
+            # Write environment info in json file.
+            # Environment file contains build_id which is an effective SHA-256 checksum of all site-packages contents.
+            # environment.json itself and __main__.py are not used to calculate the checksum which is correct
+            # because checksum is only used for local caching of site-packages and these files are always read from
+            # archive.
+            if contents_hash is not None:
+                env.build_id = contents_hash.hexdigest()
+            _write_to_zip_app(z, "environment.json", env.to_json().encode("utf-8"), zipinfo_datetime, compression,
+                              contents_hash)
 
             # write main
-            z.writestr("__main__.py", main_py.encode("utf-8"))
+            _write_to_zip_app(z, "__main__.py", main_py.encode("utf-8"), zipinfo_datetime, compression, contents_hash)
 
     # Make pyz executable (on windows this is no-op).
     target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -17,20 +17,37 @@ from .constants import DISALLOWED_ARGS, DISALLOWED_PIP_ARGS, NO_ENTRY_POINT, NO_
 __version__ = "0.0.52"
 
 
-def find_entry_point(site_packages: Path, console_script: str) -> str:
+def find_entry_point(site_packages_dirs: List[Path], console_script: str) -> str:
     """Find a console_script in a site-packages directory.
 
     Console script metadata is stored in entry_points.txt per setuptools
     convention. This function searches all entry_points.txt files and
     returns the import string for a given console_script argument.
 
-    :param site_packages: A path to a site-packages directory on disk.
+    :param site_packages_dirs: Paths to site-packages directories on disk.
     :param console_script: A console_script string.
     """
 
     config_parser = ConfigParser()
-    config_parser.read(site_packages.rglob("entry_points.txt"))
+    for site_packages in site_packages_dirs:
+        config_parser.read(site_packages.rglob("entry_points.txt"))
     return config_parser["console_scripts"][console_script]
+
+
+def console_script_exists(site_packages_dirs: List[Path], console_script: str) -> bool:
+    """Return true if the console script with provided name exists in one
+    of the site-packages directories.
+
+    Console script is expected to be in the 'bin' directory of site packages.
+
+    :param site_packages_dirs: Paths to site-packages directories on disk.
+    :param console_script: A console script name.
+    """
+    for site_packages in site_packages_dirs:
+        if (site_packages / 'bin' / console_script).exists():
+            return True
+
+    return False
 
 
 def _interpreter_path(append_version: bool = False) -> str:
@@ -97,7 +114,7 @@ def _copytree(src: Path, dst: Path) -> None:
 @click.option(
     "--site-packages",
     help="The path to an existing site-packages directory to copy into the zipapp",
-    type=click.Path(exists=True),
+    type=click.Path(exists=True), multiple=True,
 )
 @click.option("--compressed/--uncompressed", default=True, help="Whether or not to compress your zip.")
 @click.option(
@@ -140,27 +157,29 @@ def main(
             if supplied_arg in disallowed:
                 sys.exit(DISALLOWED_PIP_ARGS.format(arg=supplied_arg, reason=DISALLOWED_ARGS[disallowed]))
 
+    sources: List[Path] = []
     with TemporaryDirectory() as tmp_site_packages:
 
         # If both site_packages and pip_args are present, we need to copy the site_packages
         # dir into our staging area (tmp_site_packages) as pip may modify the contents.
         if site_packages:
             if pip_args:
-                _copytree(Path(site_packages), Path(tmp_site_packages))
+                for sp in site_packages:
+                    _copytree(Path(sp), Path(tmp_site_packages))
             else:
-                tmp_site_packages = site_packages
+                sources.extend(map(lambda p: Path(p).expanduser(), site_packages))
 
         if pip_args:
             # Install dependencies into staged site-packages.
             pip.install(["--target", tmp_site_packages] + list(pip_args))
+            sources.append(Path(tmp_site_packages).expanduser())
 
         # if entry_point is a console script, get the callable
         if entry_point is None and console_script is not None:
             try:
-                entry_point = find_entry_point(Path(tmp_site_packages), console_script)
-
+                entry_point = find_entry_point(sources, console_script)
             except KeyError:
-                if not Path(tmp_site_packages, "bin", console_script).exists():
+                if not console_script_exists(sources, console_script):
                     sys.exit(NO_ENTRY_POINT.format(entry_point=console_script))
 
         # create runtime environment metadata
@@ -176,7 +195,7 @@ def main(
 
         # create the zip
         builder.create_archive(
-            Path(tmp_site_packages).expanduser(),
+            sources,
             target=Path(output_file).expanduser(),
             interpreter=python or _interpreter_path(),
             main="_bootstrap:bootstrap",

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -1,6 +1,7 @@
+import os
 import shutil
 import sys
-import uuid
+import time
 
 from configparser import ConfigParser
 from datetime import datetime
@@ -12,7 +13,8 @@ import click
 
 from . import builder, pip
 from .bootstrap.environment import Environment
-from .constants import DISALLOWED_ARGS, DISALLOWED_PIP_ARGS, NO_ENTRY_POINT, NO_OUTFILE, NO_PIP_ARGS_OR_SITE_PACKAGES
+from .constants import BUILD_AT_TIMESTAMP_FORMAT, DISALLOWED_ARGS, DISALLOWED_PIP_ARGS, NO_ENTRY_POINT,\
+                       NO_OUTFILE, NO_PIP_ARGS_OR_SITE_PACKAGES, SOURCE_DATE_EPOCH_ENV, SOURCE_DATE_EPOCH_DEFAULT
 
 __version__ = "0.0.52"
 
@@ -128,6 +130,13 @@ def _copytree(src: Path, dst: Path) -> None:
     default=False,
     help="Add the contents of the zipapp to PYTHONPATH (for subprocesses).",
 )
+@click.option(
+    "--reproducible/--not-reproducible",
+    default=False,
+    help="Generate a reproducible zipapp by overwriting all files timestamps to a default value. "
+         "Timestamp can be overwritten by SOURCE_DATE_EPOCH env variable. "
+         "If SOURCE_DATE_EPOCH is set, this option will be implicitly set to true too.",
+)
 @click.argument("pip_args", nargs=-1, type=click.UNPROCESSED)
 def main(
     output_file: str,
@@ -138,6 +147,7 @@ def main(
     compressed: bool,
     compile_pyc: bool,
     extend_pythonpath: bool,
+    reproducible: bool,
     pip_args: List[str],
 ) -> None:
     """
@@ -182,10 +192,16 @@ def main(
                 if not console_script_exists(sources, console_script):
                     sys.exit(NO_ENTRY_POINT.format(entry_point=console_script))
 
+        # Some projects need reproducible artifacts, so they can use SOURCE_DATE_EPOCH
+        # environment variable to specify the timestamps in the zipapp
+        timestamp = int(os.environ.get(
+            SOURCE_DATE_EPOCH_ENV,
+            SOURCE_DATE_EPOCH_DEFAULT if reproducible else time.time()
+        ))
+
         # create runtime environment metadata
         env = Environment(
-            built_at=str(datetime.now()),
-            build_id=str(uuid.uuid4()),
+            built_at=datetime.utcfromtimestamp(timestamp).strftime(BUILD_AT_TIMESTAMP_FORMAT),
             entry_point=entry_point,
             script=console_script,
             compile_pyc=compile_pyc,

--- a/src/shiv/constants.py
+++ b/src/shiv/constants.py
@@ -20,3 +20,9 @@ DISALLOWED_ARGS: Dict[Tuple[str, ...], str] = {
     ("-d", "--download"): "Shiv needs to actually perform an install, not merely a download.",
     ("--user", "--root", "--prefix"): "Which conflicts with Shiv's internal use of '--target'.",
 }
+
+SOURCE_DATE_EPOCH_ENV = 'SOURCE_DATE_EPOCH'
+# This is the timestamp for beginning of the day Jan 1 1980, which is the minimum timestamp
+# value you can use in zip archives
+SOURCE_DATE_EPOCH_DEFAULT = 315554400
+BUILD_AT_TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -29,7 +29,7 @@ def package_location(request):
 
 @pytest.fixture
 def sp():
-    return Path(__file__).absolute().parent / 'sp' / 'site-packages'
+    return [Path(__file__).absolute().parent / 'sp' / 'site-packages']
 
 
 @pytest.fixture


### PR DESCRIPTION
Currently, shiv supports including only one external site-packages directory to the zipapp. This means that in cases where we need to include contents of several site-packages directories we need to first copy all of them in one single location, which can later be used in shiv, that will do one more copy of them.

To avoid this double copy that may cost 3-5 seconds per build in an average-sized project I've added the support of multiple site-packages directories in command-line options.

Testing done:

- some unit tests were fixed to support new types of arguments
- unit test added for several --site-packages options use case
- unit test added for new helper function
- manually verified that shiv CLI works as expected with several site-packages arguments