### PR TITLE
Support including multiple site-packages directories into shiv

### DIFF
--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -177,7 +177,7 @@ def main(
                 for sp in site_packages:
                     _copytree(Path(sp), Path(tmp_site_packages))
             else:
-                sources.extend(map(lambda p: Path(p).expanduser(), site_packages))
+                sources.extend([Path(p).expanduser() for p in site_packages])
 
         if pip_args:
             # Install dependencies into staged site-packages.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -29,7 +29,7 @@ def package_location(request):
 
 @pytest.fixture
 def sp():
-    return Path(__file__).absolute().parent / 'sp' / 'site-packages'
+    return [Path(__file__).absolute().parent / 'sp' / 'site-packages']
 
 
 @pytest.fixture

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from click.testing import CliRunner
-from shiv.cli import _interpreter_path, find_entry_point, main
+from shiv.cli import _interpreter_path, console_script_exists, find_entry_point, main
 from shiv.constants import DISALLOWED_ARGS, DISALLOWED_PIP_ARGS, NO_OUTFILE, NO_PIP_ARGS_OR_SITE_PACKAGES
 from shiv.info import main as info_main
 from shiv.pip import install
@@ -56,7 +56,21 @@ class TestCLI:
     def test_find_entry_point(self, tmpdir, package_location):
         """Test that we can find console_script metadata."""
         install(["-t", str(tmpdir), str(package_location)])
-        assert find_entry_point(Path(tmpdir), "hello") == "hello:main"
+        assert find_entry_point([Path(tmpdir)], "hello") == "hello:main"
+
+    def test_find_entry_point_two_points(self, tmpdir, package_location):
+        """Test that we can find console_script metadata."""
+        install(["-t", str(tmpdir), str(package_location)])
+        assert find_entry_point([Path(tmpdir)], "hello") == "hello:main"
+
+    def test_console_script_exists(self, tmpdir, package_location):
+        """Test that we can check console_script presence."""
+        install_dir = os.path.join(tmpdir, 'install')
+        install(["-t", str(install_dir), str(package_location)])
+        empty_dir = os.path.join(tmpdir, 'empty')
+        os.makedirs(empty_dir)
+
+        assert console_script_exists([Path(empty_dir), Path(install_dir)], "hello")
 
     def test_no_args(self, runner):
         """This should fail with a warning about supplying pip arguments"""
@@ -168,6 +182,37 @@ class TestCLI:
 
         pythonpath_has_root = str(shiv_root) in proc.stdout.decode()
         assert extend_path.startswith("--no") != pythonpath_has_root
+
+    def test_multiple_site_packages(self, shiv_root, runner):
+        output_file = Path(shiv_root, "test_multiple_sp.pyz")
+        package_dir = Path(shiv_root, "package")
+        main_script = Path(package_dir, "hello.py")
+
+        env_code = "\n".join(["import os", "def hello():", "    print('hello!')"])
+
+        package_dir.mkdir()
+        main_script.write_text(env_code)
+
+        other_package_dir = Path(shiv_root, "dependent_package")
+        main_script = Path(package_dir, "hello_client.py")
+
+        env_client_code = "\n".join(["import os", "from hello import hello", "def main():", "    hello()"])
+
+        other_package_dir.mkdir()
+        main_script.write_text(env_client_code)
+
+        result = runner(["-e", "hello_client:main", "-o", str(output_file), "--site-packages", str(package_dir),
+                         "--site-packages", str(other_package_dir)])
+
+        # check that the command successfully completed
+        assert result.exit_code == 0
+
+        # ensure the created file actually exists
+        assert output_file.exists()
+
+        # now run the produced zipapp and confirm that output is ok
+        proc = subprocess.run([str(output_file)], stdout=subprocess.PIPE, shell=True, env=os.environ)
+        assert 'hello!' in proc.stdout.decode()
 
     def test_no_entrypoint(self, shiv_root, runner, package_location, monkeypatch):
 


### PR DESCRIPTION
Currently, shiv supports including only one external site-packages directory to the zipapp. This means that in cases where we need to include contents of several site-packages directories we need to first copy all of them in one single location, which can later be used in shiv, that will do one more copy of them.

To avoid this double copy that may cost 3-5 seconds per build in an average-sized project I've added the support of multiple site-packages directories in command-line options.

Testing done:

- some unit tests were fixed to support new types of arguments
- unit test added for several --site-packages options use case
- unit test added for new helper function
- manually verified that shiv CLI works as expected with several site-packages arguments
