### PR TITLE
Fix default interpreter path (#148)

### DIFF
--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -64,37 +64,19 @@ def console_script_exists(site_packages_dirs: List[Path], console_script: str) -
     return False
 
 
-def _interpreter_path(append_version: bool = False) -> str:
+def _interpreter_path() -> str:
     """A function to return the path to the current Python interpreter.
 
     Even when inside a venv, this will return the interpreter the venv was created with.
 
     """
 
-    base_dir = Path(getattr(sys, "real_prefix", sys.base_prefix)).resolve()
-    sys_exec = Path(sys.executable)
-    name = sys_exec.stem
-    suffix = sys_exec.suffix
+    virtual_prefix = Path(sys.exec_prefix)
+    bin_python = Path(sys.executable).relative_to(virtual_prefix)
 
-    if append_version:
-        name += str(sys.version_info.major)
+    prefix = Path(sys.base_exec_prefix)
 
-    name += suffix
-
-    try:
-        return str(next(iter(base_dir.rglob(name))))
-
-    except StopIteration:
-
-        if not append_version:
-            # If we couldn't find an interpreter, it's likely that we looked for
-            # "python" when we should've been looking for "python3"
-            # so we try again with append_version=True
-            return _interpreter_path(append_version=True)
-
-        # If we were still unable to find a real interpreter for some reason
-        # we fallback to the current runtime's interpreter
-        return sys.executable
+    return str(prefix / bin_python)
 
 
 def _copytree(src: Path, dst: Path) -> None:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,10 +1,8 @@
-import contextlib
 import hashlib
 import json
 import os
 import stat
 import subprocess
-import sys
 import tempfile
 
 from pathlib import Path
@@ -18,15 +16,6 @@ from shiv.info import main as info_main
 from shiv.pip import install
 
 UGOX = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-
-
-@contextlib.contextmanager
-def mocked_sys_prefix():
-    attribute_to_mock = "real_prefix" if hasattr(sys, "real_prefix") else "base_prefix"
-    original = getattr(sys, attribute_to_mock)
-    setattr(sys, attribute_to_mock, "/fake/dir")
-    yield
-    setattr(sys, attribute_to_mock, original)
 
 
 class TestCLI:
@@ -95,14 +84,6 @@ class TestCLI:
 
         assert Path(interpreter).exists()
         assert Path(interpreter).is_file()
-
-    def test_find_interpreter_false(self):
-
-        with mocked_sys_prefix():
-            interpreter = _interpreter_path()
-
-        # should fall back on the current sys.executable
-        assert interpreter == sys.executable
 
     @pytest.mark.parametrize("arg", [arg for tup in DISALLOWED_ARGS.keys() for arg in tup])
     def test_disallowed_args(self, runner, arg):


### PR DESCRIPTION
As shown in the issue, the fix is straightforward according to the python docs.

It gives the proper `#!/usr/bin/python` prefix for the generated file even from a virtualenv, but I have limited access to other supported platforms (MacOS, Windows).
