### PR TITLE
Fix --extend-paths (alternative)

### DIFF
--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -140,10 +140,18 @@ def _first_sitedir_index():
             return index
 
 
-def _extend_python_path(environ, additional_paths):
+def _extend_python_path(environ, paths):
+    """Create or extend a PYTHONPATH variable with the frozen environment we are bootstrapping with."""
+
+    # we don't want to clobber any existing PYTHONPATH value, so check for it.
     python_path = environ["PYTHONPATH"].split(os.pathsep) if "PYTHONPATH" in environ else []
-    python_path.extend(additional_paths)
-    environ["PYTHONPATH"] = os.pathsep.join(python_path)
+
+    # extend the supplied paths to include any existing PYTHONPATH
+    paths.extend(python_path)
+
+    # put it back into the environment so that PYTHONPATH contains the shiv-manipulated paths
+    # and any existing PYTHONPATH values.
+    environ["PYTHONPATH"] = os.pathsep.join(set(paths))
 
 
 def bootstrap():  # pragma: no cover
@@ -172,12 +180,12 @@ def bootstrap():  # pragma: no cover
     # so as to handle .pth files correctly
     site.addsitedir(site_packages)
 
-    # add our site-packages to the environment, if requested
-    if env.extend_pythonpath:
-        _extend_python_path(os.environ, sys.path[index:])
-
     # reorder to place our site-packages before any others found
     sys.path = sys.path[:index] + sys.path[length:] + sys.path[index:length]
+
+    # add our site-packages to the environment, if requested
+    if env.extend_pythonpath:
+        _extend_python_path(os.environ, sys.path.copy())
 
     # first check if we should drop into interactive mode
     if not env.interpreter:

--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -147,11 +147,11 @@ def _extend_python_path(environ, paths):
     python_path = environ["PYTHONPATH"].split(os.pathsep) if "PYTHONPATH" in environ else []
 
     # extend the supplied paths to include any existing PYTHONPATH
-    paths.extend(python_path)
+    paths = python_path + paths
 
     # put it back into the environment so that PYTHONPATH contains the shiv-manipulated paths
     # and any existing PYTHONPATH values.
-    environ["PYTHONPATH"] = os.pathsep.join(set(paths))
+    environ["PYTHONPATH"] = os.pathsep.join(paths)
 
 
 def bootstrap():  # pragma: no cover

--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -140,18 +140,13 @@ def _first_sitedir_index():
             return index
 
 
-def _extend_python_path(environ, paths):
+def _extend_python_path(environ, additional_paths):
     """Create or extend a PYTHONPATH variable with the frozen environment we are bootstrapping with."""
 
     # we don't want to clobber any existing PYTHONPATH value, so check for it.
     python_path = environ["PYTHONPATH"].split(os.pathsep) if "PYTHONPATH" in environ else []
-
-    # extend the supplied paths to include any existing PYTHONPATH
-    paths = python_path + paths
-
-    # put it back into the environment so that PYTHONPATH contains the shiv-manipulated paths
-    # and any existing PYTHONPATH values.
-    environ["PYTHONPATH"] = os.pathsep.join(paths)
+    python_path.extend(additional_paths)
+    environ["PYTHONPATH"] = os.pathsep.join(python_path)
 
 
 def bootstrap():  # pragma: no cover

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -106,10 +106,17 @@ class TestBootstrap:
     @pytest.mark.parametrize("additional_paths", (["test"], ["test", ".pth"]))
     def test_extend_path(self, additional_paths):
 
-        env = os.environ.copy()
+        env = {}
 
         _extend_python_path(env, additional_paths)
         assert env["PYTHONPATH"] == os.pathsep.join(additional_paths)
+
+    def test_extend_path_existing_pythonpath(self):
+        """When PYTHONPATH exists, extending it preserves the existing values."""
+        env = {"PYTHONPATH": "hello"}
+
+        _extend_python_path(env, ["test", ".pth"])
+        assert env["PYTHONPATH"] == os.pathsep.join(["hello", "test", ".pth"])
 
 
 class TestEnvironment:


### PR DESCRIPTION
This is based on #140, with some changes:

1. Improved testing.
2. Undid one of the changes in #140. #140 made PYTHONPATH be _last_, but standard Python behavior is for it to be first, which was the existing `shiv` behavior. So this sticks to current behavior.

Fixes #138, I think.