### PR TITLE
Pass sys.argv[0] as archive to preamble

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -149,8 +149,8 @@ into the resulting zipapp and executed during bootstrapping.
 If the preamble file is written in Python (e.g. ends in ``.py``) then shiv will inject two variables into the runtime
 that may be useful to preamble authors:
 
+* ``archive``: path to the current PYZ file, equivalent to ``sys.argv[0]``
 * ``env``: an instance of the ``:ref:`Environment <api:bootstrap.environment.Environment>` object.
-* ``script_name``: path to the running PYZ file, equivalent to ``sys.argv[0]``
 * ``site_packages``: a pathlib.Path of the directory where the current PYZ's site_packages were extracted to during bootsrap.
 
 For an example, a preamble file that cleans up prior extracted ``~/.shiv`` directories might look like::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -150,6 +150,7 @@ If the preamble file is written in Python (e.g. ends in ``.py``) then shiv will 
 that may be useful to preamble authors:
 
 * ``env``: an instance of the ``:ref:`Environment <api:bootstrap.environment.Environment>` object.
+* ``script_path``: path to the running PYZ file, equivalent to ``sys.argv[0]``
 * ``site_packages``: a pathlib.Path of the directory where the current PYZ's site_packages were extracted to during bootsrap.
 
 For an example, a preamble file that cleans up prior extracted ``~/.shiv`` directories might look like::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -150,7 +150,7 @@ If the preamble file is written in Python (e.g. ends in ``.py``) then shiv will 
 that may be useful to preamble authors:
 
 * ``env``: an instance of the ``:ref:`Environment <api:bootstrap.environment.Environment>` object.
-* ``script_path``: path to the running PYZ file, equivalent to ``sys.argv[0]``
+* ``script_name``: path to the running PYZ file, equivalent to ``sys.argv[0]``
 * ``site_packages``: a pathlib.Path of the directory where the current PYZ's site_packages were extracted to during bootsrap.
 
 For an example, a preamble file that cleans up prior extracted ``~/.shiv`` directories might look like::

--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -218,7 +218,7 @@ def bootstrap():  # pragma: no cover
         if preamble_bin.suffix == ".py":
             runpy.run_path(
                 preamble_bin,
-                init_globals={"env": env, "script_name": sys.argv[0], "site_packages": site_packages},
+                init_globals={"archive": sys.argv[0], "env": env, "site_packages": site_packages},
                 run_name="__main__",
             )
 

--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -218,7 +218,7 @@ def bootstrap():  # pragma: no cover
         if preamble_bin.suffix == ".py":
             runpy.run_path(
                 preamble_bin,
-                init_globals={"env": env, "site_packages": site_packages},
+                init_globals={"env": env, "script_path": sys.argv[0], "site_packages": site_packages},
                 run_name="__main__",
             )
 

--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -218,7 +218,7 @@ def bootstrap():  # pragma: no cover
         if preamble_bin.suffix == ".py":
             runpy.run_path(
                 preamble_bin,
-                init_globals={"env": env, "script_path": sys.argv[0], "site_packages": site_packages},
+                init_globals={"env": env, "script_name": sys.argv[0], "site_packages": site_packages},
                 run_name="__main__",
             )
 


### PR DESCRIPTION
@lorencarvalho Here's my proposal to address https://github.com/linkedin/shiv/pull/156#discussion_r488960708

I think `script_name` is a fairly canonical way to refer to [`sys.argv[0]`](https://docs.python.org/3/library/sys.html#sys.argv), and I think it's a reasonable variable to add to `init_globals` _specifically_ because `runpy` modifies the value in place before running code.

Thoughts? 🤞 

---

**Update:** Switched `script_name` to `archive` to be less ambiguous and for consistency with another reference in `bootstrap.__init__`