### PR TITLE
Fix 'developing' section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ We'd love contributions! Getting bootstrapped to develop is easy:
 git clone git@github.com:linkedin/shiv.git
 cd shiv
 python3 -m venv venv
-./venv/bin activate
+source ./venv/bin/activate
 python3 setup.py develop
 ```
 


### PR DESCRIPTION
The current directions for getting bootstrapped fail to activate the venv. This change fixes that.

```
$ > cd ~/tmp/
$ > git clone git@github.com:linkedin/shiv.git
Cloning into 'shiv'...
remote: Enumerating objects: 19, done.
remote: Counting objects: 100% (19/19), done.
remote: Compressing objects: 100% (14/14), done.
remote: Total 1142 (delta 4), reused 8 (delta 2), pack-reused 1123
Receiving objects: 100% (1142/1142), 239.70 KiB | 1.43 MiB/s, done.
Resolving deltas: 100% (677/677), done.

$ > cd shiv/
$ > python3 -m venv venv
$ > ./venv/bin activate
bash: ./venv/bin: is a directory
$ > ./venv/bin/activate
bash: ./venv/bin/activate: Permission denied
$ > source ./venv/bin/activate
$ > which python
$USER/tmp/shiv/venv/bin/python
```