### PR TITLE
Add functionality for "SHIV_CONSOLE_SCRIPT" similar to the existing "SHIV_ENTRY_POINT" environment variable hint.

### DIFF
--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -33,6 +33,9 @@ def run(module):  # pragma: no cover
     with suppress(KeyError):
         del os.environ[Environment.ENTRY_POINT]
 
+    with suppress(KeyError):
+        del os.environ[Environment.CONSOLE_SCRIPT]
+
     sys.exit(module())
 
 
@@ -241,7 +244,7 @@ def bootstrap():  # pragma: no cover
             run(import_string(env.entry_point))
 
         elif env.script is not None:
-            run(partial(runpy.run_path, site_packages / "bin" / env.script, run_name="__main__"))
+            run(partial(runpy.run_path, str(site_packages / "bin" / env.script), run_name="__main__"))
 
     # all other options exhausted, drop into interactive mode
     execute_interpreter()

--- a/src/shiv/bootstrap/environment.py
+++ b/src/shiv/bootstrap/environment.py
@@ -15,6 +15,7 @@ def str_bool(v):
 class Environment:
     INTERPRETER = "SHIV_INTERPRETER"
     ENTRY_POINT = "SHIV_ENTRY_POINT"
+    CONSOLE_SCRIPT = "SHIV_CONSOLE_SCRIPT"
     MODULE = "SHIV_MODULE"
     ROOT = "SHIV_ROOT"
     FORCE_EXTRACT = "SHIV_FORCE_EXTRACT"
@@ -44,7 +45,6 @@ class Environment:
         self.hashes = hashes or {}
         self.no_modify = no_modify
         self.reproducible = reproducible
-        self.script = script
         self.shiv_version = shiv_version
         self.preamble = preamble
 
@@ -53,6 +53,7 @@ class Environment:
         self._compile_pyc = compile_pyc
         self._extend_pythonpath = extend_pythonpath
         self._root = root
+        self._script = script
 
     @classmethod
     def from_json(cls, json_data):
@@ -67,6 +68,10 @@ class Environment:
     @property
     def entry_point(self):
         return os.environ.get(self.ENTRY_POINT, os.environ.get(self.MODULE, self._entry_point))
+
+    @property
+    def script(self):
+        return os.environ.get(self.CONSOLE_SCRIPT, self._script)
 
     @property
     def interpreter(self):

--- a/test/test_bootstrap.py
+++ b/test/test_bootstrap.py
@@ -131,6 +131,10 @@ class TestEnvironment:
         with env_var("SHIV_ENTRY_POINT", "test"):
             assert env.entry_point == "test"
 
+        assert env.script is None
+        with env_var("SHIV_CONSOLE_SCRIPT", "test"):
+            assert env.script == "test"
+
         assert env.interpreter is None
         with env_var("SHIV_INTERPRETER", "1"):
             assert env.interpreter is not None

--- a/test_file
+++ b/test_file
@@ -1,0 +1,1 @@
+#!/usr/bin/env python


### PR DESCRIPTION
Now, instead of needing to know the exact import string, you only need
to know the name of the console script that a package provides.

Fixes #175