### PR TITLE
Pass arg to runpy.run_path() as string not Path (#163)

### DIFF
--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -228,7 +228,7 @@ def bootstrap():  # pragma: no cover
 
         if preamble_bin.suffix == ".py":
             runpy.run_path(
-                preamble_bin,
+                preamble_bin.as_posix(),
                 init_globals={"archive": sys.argv[0], "env": env, "site_packages": site_packages},
                 run_name="__main__",
             )


### PR DESCRIPTION
Issue #163 is a compatibility problem with some versions of Python in which runpy's `run_path()` function does not expect the first argument to be a pathlib `Path` object. The simplest fix is to convert the argument to a string before passing it to `run_path()`.