### PR TITLE
enable shiv with no pip_args nor site_packages

### DIFF
--- a/docs/cli-reference.rst
+++ b/docs/cli-reference.rst
@@ -40,3 +40,7 @@ Also note that you can always fix the shebang during installation of a zipapp us
 .. code-block:: shell
 
    python3 -m zipapp -p '/usr/bin/env python3.7' -o ~/bin/foo foo.pyz
+
+If the interpreter you run is different from the interpreter of the sheband line,
+you can use the :option:`--pip-use-shebang-python` to use the shebang interpreter when installing packages through pip
+(important for version specific packages).

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -178,8 +178,12 @@ def main(
     as outlined in PEP 441, but with all their dependencies included!
     """
 
-    if not pip_args and not site_packages:
-        sys.exit(NO_PIP_ARGS_OR_SITE_PACKAGES)
+    if pip_args is None:
+        pip_args = []
+        
+    # convert a str pip_args to a list of str
+    if isinstance(pip_args, str):
+        pip_args = pip_args.split()
 
     if output_file is None:
         sys.exit(NO_OUTFILE)

--- a/src/shiv/pip.py
+++ b/src/shiv/pip.py
@@ -28,10 +28,10 @@ def clean_pip_env() -> Generator[None, None, None]:
             os.environ[PIP_REQUIRE_VIRTUALENV] = require_venv
 
 
-def install(args: List[str]) -> None:
+def install(args: List[str], pip_interpreter: str) -> None:
     """`pip install` as a function.
 
-    Accepts a list of pip arguments.
+    Accepts a list of pip arguments and the python interpreter to use when running pip.
 
     .. code-block:: py
 
@@ -54,7 +54,7 @@ def install(args: List[str]) -> None:
         extend_python_path(subprocess_env, sys.path[sitedir_index:])
 
         process = subprocess.Popen(
-            [sys.executable, "-m", "pip", "--disable-pip-version-check", "install", *args],
+            [pip_interpreter, "-m", "pip", "--disable-pip-version-check", "install", *args],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=subprocess_env,


### PR DESCRIPTION
Currently shiv does not support to provide empty pip_args or no site_packages in the CLI.
This PR fixes that and also adapt the create_archive to handle an empty /site-packages/ folder.
It also ensures that the pip_args is a list of str. If pip_args is just a str, it will be splitted (today, if pip_args=="pip", it will install the "p" and the "i" package)