### PR TITLE
Fix build_id not changed when a file is renamed

### DIFF
--- a/src/shiv/builder.py
+++ b/src/shiv/builder.py
@@ -120,6 +120,8 @@ def create_archive(
 
                     # update the contents hash
                     contents_hash.update(data)
+                    # take filenames into account as well - build_id should change if a file is moved or renamed
+                    contents_hash.update(str(path.relative_to(source)).encode())
 
                     arcname = str(site_packages / path.relative_to(source))
 


### PR DESCRIPTION
Shiv has to take filenames into account when calculating build_id, otherwise if the only change in the zipapp is a rename - this will result in the same build_id, and the newly built zipapp won't be unpacked if there's already an older version in the cache. This is obviously an issue for zipapps which contain data files (i.e. not referenced by code directly); for example, this may break "preamble" if the preamble file is renamed but the rest of the archive remains the same - if the zipapp has already been executed, the new preamble file will be called but an old cache folder will be used, where the file is called differently.