### PR TITLE
Fix default sys.path injected into PYTHONPATH

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 
 [metadata]
 name = shiv
-version = 1.0.2
+version = 1.0.3
 description = A command line utility for building fully self contained Python zipapps.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/shiv/bootstrap/__init__.py
+++ b/src/shiv/bootstrap/__init__.py
@@ -208,6 +208,9 @@ def bootstrap():  # pragma: no cover
     # Find the first instance of an existing site-packages on sys.path
     index = get_first_sitedir_index() or length
 
+    # copy sys.path to determine diff
+    sys_path_before = sys.path.copy()
+
     # append site-packages using the stdlib blessed way of extending path
     # so as to handle .pth files correctly
     site.addsitedir(site_packages)
@@ -215,13 +218,16 @@ def bootstrap():  # pragma: no cover
     # reorder to place our site-packages before any others found
     sys.path = sys.path[:index] + sys.path[length:] + sys.path[index:length]
 
+    # determine newly added paths
+    new_paths = [p for p in sys.path if p not in sys_path_before]
+
     # check if source files have been modified, if required
     if env.no_modify:
         ensure_no_modify(site_packages, env.hashes)
 
-    # add our site-packages to the environment, if requested
+    # add any new paths to the environment, if requested
     if env.extend_pythonpath:
-        extend_python_path(os.environ, sys.path.copy())
+        extend_python_path(os.environ, new_paths)
 
     # if a preamble script was provided, run it
     if env.preamble:

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -26,7 +26,7 @@ from .constants import (
     SOURCE_DATE_EPOCH_ENV,
 )
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 
 def find_entry_point(site_packages_dirs: List[Path], console_script: str) -> str:


### PR DESCRIPTION
When SHIV_EXTEND_PYTHONPATH is used, PYTHONPATH env variable gets not only zipapp site-packages and other new stuff, but also the default sys.path of the current Python (for ex. Python3.10). This breaks ability to run a different version of Python in a subprocess, because PYTHONPATH takes precedence over default sys.path, and so a subprocess starting Python3.9 will attempt to use Python 3.10 builtin modules, and will most likely break in unpredictable ways. This change fixes that by only adding new paths which appear after injecting zipapp site-packages.