### PR TITLE
Move default cache root from ~/.shiv to ~/.cache/shiv

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ sphinx-build docs build/html
 Zipapps created with shiv are not guaranteed to be cross-compatible with other architectures. For example, a `pyz`
  file built on a Mac may only work on other Macs, likewise for RHEL, etc. This usually only applies to zipapps that have C extensions in their dependencies. If all your dependencies are pure python, then chances are the `pyz` _will_ work on other platforms. Just something to be aware of.
 
-Zipapps created with shiv *will* extract themselves into `~/.shiv`, unless overridden via
+Zipapps created with shiv *will* extract themselves into `~/.cache/shiv` (platform dependent), unless overridden via
 `SHIV_ROOT`. If you create many utilities with shiv, you may want to occasionally clean this
 directory.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -93,7 +93,7 @@ Bootstrapping
 ^^^^^^^^^^^^^
 
 As mentioned above, when you run an executable created with ``shiv``, a special bootstrap function is called.
-This function unpacks the dependencies into a uniquely named subdirectory of ``~/.shiv`` and then runs your entry point
+This function unpacks the dependencies into a uniquely named subdirectory of ``~/.cache/shiv`` (platform dependent) and then runs your entry point
 (or interactive interpreter) with those dependencies added to your interpreter's search path (``sys.path``).
 
 To improve performance, once the dependencies have been extracted to disk, any further invocations will re-use the 'cached'
@@ -126,7 +126,7 @@ If the preamble file is written in Python (e.g. ends in ``.py``) then shiv will 
 * ``env``: an instance of the `Environment <api:bootstrap.environment.Environment>`_ object.
 * ``site_packages``: a :py:class:`pathlib.Path` of the directory where the current PYZ's site_packages were extracted to during bootstrap.
 
-For an example, a preamble file that cleans up prior extracted ``~/.shiv`` directories might look like:
+For an example, a preamble file that cleans up prior extracted ``~/.cache/shiv`` directories might look like:
 
 .. code-block:: py
 
@@ -225,7 +225,7 @@ you can specify to influence a zipapp created with shiv at run time.
 SHIV_ROOT
 ^^^^^^^^^
 
-This should be populated with a full path, it overrides ``~/.shiv`` as the default base dir for shiv's extraction cache.
+This should be populated with a full path, it overrides ``~/.cache/shiv`` (platform dependent) as the default base dir for shiv's extraction cache.
 
 This is useful if you want to collect the contents of a zipapp to inspect them, or if you want to make a quick edit to
 a source file, but don't want to taint the extraction cache.

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -143,7 +143,7 @@ def copytree(src: Path, dst: Path) -> None:
     is_flag=True,
     help=(
         "If specified, this modifies the runtime of the zipapp to raise "
-        "a RuntimeException if the source files (in ~/.shiv or SHIV_ROOT) have been modified. "
+        "a RuntimeException if the source files (in ~/.cache/shiv or SHIV_ROOT) have been modified. "
         """It's recommended to use Python's "--check-hash-based-pycs always" option with this feature."""
     ),
 )
@@ -155,7 +155,11 @@ def copytree(src: Path, dst: Path) -> None:
         "but before invoking your entry point."
     ),
 )
-@click.option("--root", type=click.Path(), help="Override the 'root' path (default is ~/.shiv).")
+@click.option(
+    "--root",
+    type=click.Path(),
+    help="Override the 'root' path (default is platform dependent, e.g. ~/.cache/shiv).",
+)
 @click.argument("pip_args", nargs=-1, type=click.UNPROCESSED)
 def main(
     output_file: str,


### PR DESCRIPTION
More precisely:

1. if $SHIV_ROOT is set, use it
2. if --root is set, use it
3. if ~/.shiv already exists, use it
4. on Windows: %LOCALAPPDATA%\shiv\cache
5. on macOS: ~/Library/Caches/shiv
6. on other: $XDG_CACHE_HOME/shiv or ~/.cache/shiv

Motivation:

- Purely aesthetic reasons :) Less junk in $HOME.
- The location makes it more obvious that it's just a cache. --> Users should feel free to delete it.
- Some backup software will ignore caches by default.

Implementation:

This is [an ad hoc, informally-specified, bug-ridden, slow implementation](https://en.wikipedia.org/wiki/Greenspun%27s_tenth_rule) of 1% of [platformdirs](https://github.com/platformdirs/platformdirs). platformdirs is the most common library for this, for example it is used by pip to locate its own cache (~/.cache/pip). I didn't want to use platformdirs directly because this code is embedded into .pyz files and shouldn't have any dependencies. The main differences from the original platformdirs algorithm are that Windows only checks getenv (not ctypes/windll or registry) ([see also](https://github.com/platformdirs/platformdirs/blob/main/src/platformdirs/windows.py)), Windows falls back to Unix if getenv fails, and Android is not special cased ([see also](https://github.com/platformdirs/platformdirs/blob/main/src/platformdirs/android.py)).

**Please test!!:**

I don't have a Windows or macOS development setup. I'd be grateful if someone could check that it works, and that the directory is created nearby to pip's cache (probably %LOCALAPPDATA%\pip\cache, ~/Library/Caches/pip).