### PR TITLE
Adding inline script metadata (pep-723) support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
   click>=6.7,!=7.0
   pip>=9.0.3
   setuptools
+  packaging
 python_requires = >=3.8
 include_package_data = True
 

--- a/src/shiv/bootstrap/environment.py
+++ b/src/shiv/bootstrap/environment.py
@@ -39,6 +39,7 @@ class Environment:
         no_modify: bool = False,
         reproducible: bool = False,
         script: Optional[str] = None,
+        inline_script: Optional[str] = None,
         preamble: Optional[str] = None,
         root: Optional[str] = None,
     ) -> None:
@@ -50,6 +51,7 @@ class Environment:
         self.no_modify: bool = no_modify
         self.reproducible: bool = reproducible
         self.preamble: Optional[str] = preamble
+        self.inline_script: Optional[str] = inline_script
 
         # properties
         self._entry_point: Optional[str] = entry_point

--- a/src/shiv/cli.py
+++ b/src/shiv/cli.py
@@ -6,7 +6,10 @@ import time
 
 from configparser import ConfigParser
 from datetime import datetime
+from packaging.version import Version
+from packaging.specifiers import SpecifierSet
 from pathlib import Path
+from platform import python_version
 from tempfile import TemporaryDirectory
 from typing import List, Optional
 
@@ -27,6 +30,7 @@ from .constants import (
     SCRIPT_NOT_ANNOTATED,
     SOURCE_DATE_EPOCH_DEFAULT,
     SOURCE_DATE_EPOCH_ENV,
+    MIN_PYTHON_VERSION_ERROR,
 )
 
 
@@ -228,6 +232,9 @@ def main(
             if "script" not in metadata:
                 sys.exit(SCRIPT_NOT_ANNOTATED)
             script_dependencies = metadata["script"].get("dependencies", [])
+            min_python = metadata["script"].get("requires-python", None)
+            if min_python and Version(python_version()) not in SpecifierSet(min_python):
+                sys.exit(MIN_PYTHON_VERSION_ERROR.format(min_python=min_python, python_version=python_version()))
             if script_dependencies:
                 pip.install(["--target", tmp_site_packages] + list(script_dependencies))
             console_script = Path(inline_script).name

--- a/src/shiv/constants.py
+++ b/src/shiv/constants.py
@@ -3,7 +3,8 @@ from typing import Dict, Tuple
 
 # errors:
 DISALLOWED_PIP_ARGS = "\nYou supplied a disallowed pip argument! '{arg}'\n\n{reason}\n"
-NO_PIP_ARGS_OR_SITE_PACKAGES = "\nYou must supply PIP ARGS or --site-packages!\n"
+NO_PIP_ARGS_SCRIPT_OR_SITE_PACKAGES = "\nYou must supply PIP ARGS, --script, or --site-packages!\n"
+SCRIPT_NOT_ANNOTATED = "\nThe provided script is not annotated with PEP-723 metadata!\n"
 NO_OUTFILE = "\nYou must provide an output file option! (--output-file/-o)\n"
 NO_ENTRY_POINT = "\nNo entry point '{entry_point}' found in console_scripts or the bin dir!\n"
 BINPRM_ERROR = "\nShebang is too long, it would exceed BINPRM_BUF_SIZE! Consider /usr/bin/env\n"

--- a/src/shiv/constants.py
+++ b/src/shiv/constants.py
@@ -5,6 +5,7 @@ from typing import Dict, Tuple
 DISALLOWED_PIP_ARGS = "\nYou supplied a disallowed pip argument! '{arg}'\n\n{reason}\n"
 NO_PIP_ARGS_SCRIPT_OR_SITE_PACKAGES = "\nYou must supply PIP ARGS, --script, or --site-packages!\n"
 SCRIPT_NOT_ANNOTATED = "\nThe provided script is not annotated with PEP-723 metadata!\n"
+MIN_PYTHON_VERSION_ERROR = "\nThe provided script requires Python {min_python}, but you are using {python_version}!\n"
 NO_OUTFILE = "\nYou must provide an output file option! (--output-file/-o)\n"
 NO_ENTRY_POINT = "\nNo entry point '{entry_point}' found in console_scripts or the bin dir!\n"
 BINPRM_ERROR = "\nShebang is too long, it would exceed BINPRM_BUF_SIZE! Consider /usr/bin/env\n"

--- a/src/shiv/inline_script.py
+++ b/src/shiv/inline_script.py
@@ -1,0 +1,31 @@
+import re
+try:
+    # python 3.11+ has tomllib in stdlib
+    import tomllib  # type: ignore
+except (ModuleNotFoundError, ImportError):
+    # python 3.8-3.10, use pip vendored tomli
+    import pip._vendor.tomli as tomllib  # type: ignore
+
+REGEX = r'(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$'
+
+
+def parse_script_metadata(script: str) -> dict:
+    """Parses the metadata from a PEP-723 annotated script.
+
+    The metadata is stored in a nested dictionary structure.
+    The only PEP defined metadata type is "script", which contains the
+    dependencies of the script and minimum Python version.
+
+    :param script: The text of the script to parse.
+    """
+
+    metadata = {}
+
+    for match in re.finditer(REGEX, script):
+        md_type, content = match.group('type'), ''.join(
+            line[2:] if line.startswith('# ') else line[1:]
+            for line in match.group('content').splitlines(keepends=True)
+        )
+        metadata[md_type] = tomllib.loads(content)
+
+    return metadata

--- a/test/script/deps.py
+++ b/test/script/deps.py
@@ -1,0 +1,17 @@
+# /// script
+# dependencies = [
+#   "pyyaml<7",
+#   "rich",
+# ]
+# ///
+
+import yaml
+from rich.pretty import pprint
+
+document = """
+  hello: world
+  foo:
+    bar: 1
+    baz: 2
+"""
+pprint(yaml.safe_load(document))

--- a/test/script/deps_and_python.py
+++ b/test/script/deps_and_python.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.8"
 # dependencies = [
 #   "python-dateutil",
 #   "rich",

--- a/test/script/deps_and_python.py
+++ b/test/script/deps_and_python.py
@@ -1,0 +1,29 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "python-dateutil",
+#   "rich",
+# ]
+# ///
+
+# Code from https://pypi.org/project/python-dateutil/
+# Description:
+# Suppose you want to know how much time is left, in years/months/days/etc,
+# before the next easter happening on a year with a Friday 13th in August,
+# and you want to get today’s date out of the “date” unix system command.
+
+from dateutil.relativedelta import relativedelta, FR
+from dateutil.easter import easter
+from dateutil.rrule import rrule, YEARLY
+from dateutil.parser import parse
+from rich.pretty import pprint
+
+now = parse("Sat Oct 11 17:13:46 UTC 2003")
+today = now.date()
+year = rrule(YEARLY, dtstart=now, bymonth=8, bymonthday=13, byweekday=FR)[0].year
+rdelta = relativedelta(easter(year), today)
+
+pprint(f"Today is: {today}")
+pprint(f"Year with next Aug 13th on a Friday is: {year}")
+pprint(f"How far is the Easter of that year: {rdelta}")
+pprint(f"And the Easter of that year is: {today+rdelta}")

--- a/test/script/min_python.py
+++ b/test/script/min_python.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.8"
 # ///
 
 # No external dependencies

--- a/test/script/min_python.py
+++ b/test/script/min_python.py
@@ -1,0 +1,17 @@
+# /// script
+# requires-python = ">=3.11"
+# ///
+
+# No external dependencies
+
+import json
+
+document = {
+    "hello": "world",
+    "foo": {
+        "bar": 1,
+        "baz": 2,
+    },
+}
+
+print(json.dumps(document))

--- a/test/test_inline_script.py
+++ b/test/test_inline_script.py
@@ -19,12 +19,12 @@ class TestInlineScript:
             }),
             ("test/script/min_python.py", {
                 "script": {
-                    "requires-python": ">=3.11",
+                    "requires-python": ">=3.8",
                 }
             }),
             ("test/script/deps_and_python.py", {
                 "script": {
-                    "requires-python": ">=3.11",
+                    "requires-python": ">=3.8",
                     "dependencies": [
                         "python-dateutil",
                         "rich",

--- a/test/test_inline_script.py
+++ b/test/test_inline_script.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+
+from shiv.inline_script import parse_script_metadata
+
+
+class TestInlineScript:
+    @pytest.mark.parametrize(
+        "script_location,expected_metadata",
+        [
+            ("test/script/deps.py", {
+                "script": {
+                    "dependencies": [
+                        "pyyaml<7",
+                        "rich"
+                    ],
+                }
+            }),
+            ("test/script/min_python.py", {
+                "script": {
+                    "requires-python": ">=3.11",
+                }
+            }),
+            ("test/script/deps_and_python.py", {
+                "script": {
+                    "requires-python": ">=3.11",
+                    "dependencies": [
+                        "python-dateutil",
+                        "rich",
+                    ],
+                }
+            }),
+            ("test/package/hello/__init__.py", {}),
+        ],
+    )
+    def test_parse_script_metadata(self, script_location, expected_metadata):
+        script_text = Path(script_location).read_text()
+        assert parse_script_metadata(script_text) == expected_metadata

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 isolated_build = True
-envlist = py38, py39, py310, py311
+envlist = py38, py39, py310, py311, py312
+
 
 [gh-actions]
 python =
@@ -8,6 +9,7 @@ python =
   3.9: py39
   3.10: py310
   3.11: py311
+  3.12: py312
 
 [testenv]
 commands=


### PR DESCRIPTION
Fixes #266

Adds support for [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#inline-script-metadata) to specify dependencies and minimum python version. It is used when `--inline-script` or `-s` is passed with a path to the script you want to use.

Also adding tests to verify the functionality.