### PR TITLE
Fix: Ensure deterministic file ordering in `iter_package_files`

### DIFF
--- a/src/shiv/builder.py
+++ b/src/shiv/builder.py
@@ -31,13 +31,13 @@ except ImportError:
 # N.B.: `importlib.resources.{contents,is_resource,path}` are deprecated in 3.11 and gone in 3.13.
 if sys.version_info < (3, 11):
     def iter_package_files(package: Union[str, ModuleType]) -> Iterator[Tuple[Path, str]]:
-        for bootstrap_file in importlib_resources.contents(bootstrap):
+        for bootstrap_file in sorted(importlib_resources.contents(package)):
             if importlib_resources.is_resource(bootstrap, bootstrap_file):
                 with importlib_resources.path(bootstrap, bootstrap_file) as path:
                     yield (path, bootstrap_file)
 else:
     def iter_package_files(package: Union[str, ModuleType]) -> Iterator[Tuple[Path, str]]:
-        for resource in importlib_resources.files(package).iterdir():
+        for resource in sorted(importlib_resources.files(package).iterdir(), key=lambda r: r.name):
             if resource.is_file():
                 with importlib_resources.as_file(resource) as path:
                     yield (path, resource.name)


### PR DESCRIPTION
cc @lorencarvalho

### Summary
Fixed non-deterministic file ordering in the `iter_package_files` function by adding explicit sorting of package files. This change ensures consistent behavior across builds and prevents issues caused by unordered file iteration.

### Changes Made
- Applied `sorted()` to file listings in both Python versions (<3.11 and >=3.11).
- Guaranteed that files are processed in a consistent, lexicographic order.

### Why This Fix?
- Prevents non-deterministic builds caused by unordered file iteration.
- Improves build reproducibility and enables better caching in CI/CD pipelines.
- Simplifies code by enforcing consistent ordering within the function, reducing the need for manual sorting in callers.

### Testing
- Rebuilt the project multiple times and verified that output files are now consistent across builds.
- Compared generated artifacts (e.g., `.json` files) to confirm deterministic ordering.

### Impact
- No functional changes to how files are processed, only improves determinism.
- Safer and more reliable builds, especially in CI environments.

Closes https://github.com/linkedin/shiv/issues/265