### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: "upload coverage to codecov"
         if: ${{ github.event_name == 'push' }}
-        uses: "codecov/codecov-action@v1"
+        uses: "codecov/codecov-action@v5"
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `codecov/codecov-action` | [`v1`](https://github.com/codecov/codecov-action/releases/tag/v1) | [`v5`](https://github.com/codecov/codecov-action/releases/tag/v5) | [Release](https://github.com/codecov/codecov-action/releases/tag/v5) | tox.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
