### PR TITLE
ci: set explicit read-only permissions on CI workflow

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Declares `permissions: contents: read` on the CI workflow. The workflow only checks out code, installs pip dependencies, and runs tox tests. It does not need write access to any GitHub API scope.

Restricting the token scope is recommended by the OpenSSF Scorecard project and limits exposure in the event a third-party action is compromised.